### PR TITLE
Allow ordered operations via plugin order

### DIFF
--- a/pkg/plugin/aggregation/aggregator.go
+++ b/pkg/plugin/aggregation/aggregator.go
@@ -100,6 +100,22 @@ func (a *Aggregator) isComplete() bool {
 	return true
 }
 
+// currentOrder returns the order of lowest order plugin which doesn't have a result yet. If all have results then -1 is returned.
+func (a *Aggregator) currentOrder() int {
+	lowestWithoutResults := -1
+	set := false
+	for _, result := range a.ExpectedResults {
+		if _, ok := a.Results[result.ID()]; !ok {
+			if result.Order < lowestWithoutResults || !set {
+				lowestWithoutResults = result.Order
+				set = true
+			}
+		}
+	}
+
+	return lowestWithoutResults
+}
+
 func (a *Aggregator) isResultExpected(result *plugin.Result) bool {
 	_, ok := a.ExpectedResults[result.ExpectedResultID()]
 	return ok

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -66,6 +66,11 @@ func (b *Base) GetName() string {
 	return b.Definition.Name
 }
 
+// GetIOrder returns the order of this Job plugin.
+func (b *Base) GetOrder() int {
+	return b.Definition.Order
+}
+
 // GetSecretName gets a name for a secret based on the plugin name and session ID.
 func (b *Base) GetSecretName() string {
 	return fmt.Sprintf("sonobuoy-plugin-%s-%s", b.GetName(), b.GetSessionID())

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -68,6 +68,7 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 		ret = append(ret, plugin.ExpectedResult{
 			NodeName:   node.Name,
 			ResultType: p.GetResultType(),
+			Order:      p.Definition.Order,
 		})
 	}
 

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -63,7 +63,10 @@ func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy 
 // a Job only launches one pod, only one result type is expected.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return []plugin.ExpectedResult{
-		plugin.ExpectedResult{ResultType: p.GetResultType()},
+		plugin.ExpectedResult{
+			ResultType: p.GetResultType(),
+			Order:      p.Definition.Order,
+		},
 	}
 }
 

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -49,6 +49,8 @@ type Interface interface {
 	GetResultType() string
 	// GetName returns the name of this plugin
 	GetName() string
+	// GetOrder returns the order in which the plugin is run. Plugins will wait until all other plugins with lower order are done before being launched.
+	GetOrder() int
 }
 
 // Definition defines a plugin's features, method of launch, and other
@@ -56,6 +58,7 @@ type Interface interface {
 type Definition struct {
 	Name         string
 	ResultType   string
+	Order        int
 	Spec         manifest.Container
 	ExtraVolumes []manifest.Volume
 }
@@ -65,6 +68,7 @@ type Definition struct {
 type ExpectedResult struct {
 	NodeName   string
 	ResultType string
+	Order      int
 }
 
 // Result represents a result we got from a dispatched plugin, returned to the

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -122,6 +122,7 @@ func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolic
 		ResultType:   def.SonobuoyConfig.ResultType,
 		ExtraVolumes: def.ExtraVolumes,
 		Spec:         def.Spec,
+		Order:        def.SonobuoyConfig.Order,
 	}
 
 	switch def.SonobuoyConfig.Driver {

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -27,6 +27,7 @@ type SonobuoyConfig struct {
 	Driver     string `json:"driver"`
 	PluginName string `json:"plugin-name"`
 	ResultType string `json:"result-type"`
+	Order      int    `json:"order"`
 	objectKind
 }
 
@@ -36,6 +37,7 @@ func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 		Driver:     s.Driver,
 		PluginName: s.PluginName,
 		ResultType: s.ResultType,
+		Order:      s.Order,
 		objectKind: objectKind{s.objectKind.gvk},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change introduces the concept of plugin order. It
is backwards compatible since the default value is 0
which can execute with without precondition.

A plugin can only be executed after all plugins of lower
order have reported results.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Which issue(s) this PR fixes**
Fixes #39

**Special notes for your reviewer**:

**Release note**:
```
Add support for ordered operations via plugin "order" field.
```
