### PR TITLE
Allow piping input to sonobuoy run

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -924,6 +924,7 @@
     "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/viniciuschiele/tarx",
+    "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/sync/errgroup",
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -26,10 +26,10 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	ops "github.com/vmware-tanzu/sonobuoy/pkg/client"
-	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	ops "github.com/vmware-tanzu/sonobuoy/pkg/client"
+	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -20,10 +20,10 @@ import (
 	"io"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -110,14 +110,20 @@ type E2EConfig struct {
 // RunConfig are the input options for running Sonobuoy.
 type RunConfig struct {
 	GenConfig
+	GenFile    string
 	Wait       time.Duration
 	WaitOutput string
 }
 
 // Validate checks the config to determine if it is valid.
 func (rc *RunConfig) Validate() error {
-	err := rc.GenConfig.Validate()
-	return errors.Wrap(err, "GenConfig validation failed")
+	// If given a manifest, just load it as-is.
+	if len(rc.GenFile) == 0 {
+		err := rc.GenConfig.Validate()
+		return errors.Wrap(err, "GenConfig validation failed")
+	}
+
+	return nil
 }
 
 // DeleteConfig are the input options for cleaning up a Sonobuoy run.

--- a/pkg/client/run_test.go
+++ b/pkg/client/run_test.go
@@ -38,6 +38,16 @@ func TestRunInvalidConfig(t *testing.T) {
 			config:           &RunConfig{},
 			expectedErrorMsg: "config validation failed",
 		},
+		{
+			desc: "Passing a file takes priority over config flags",
+			config: &RunConfig{
+				GenFile: "foo.yaml",
+			},
+			expectedErrorMsg: "no such file or directory",
+		},
+		// NOTE: Running non-failing logic here is not supported at this time due to the fact
+		// that it tries to actually start executing logic with the dynamic client which
+		// is nil.
 	}
 
 	c, err := NewSonobuoyClient(nil, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Often a user wants to use `sonbouoy gen` to generate some YAML and
then modify it using tools like jq or yq. We even have this workflow
documented and the user has to, end the end, pipe the data into
`kubectl apply -f`.

`sonobuoy run` is just a shorthand for `sonobuoy gen` + execute with
wait logic; it makes sense to allow loading a file or piping the data
from stdin.

This PR:
 - adds a --file, -f flag to `sonobuoy run`
 - if the value is `-` it will load from stdin, erroring if it is not
connected to a terminal.

It does not add a unit test for this since the `sonobuoy run` logic
is difficult to test in a unit test since it wants to talk to a real cluster.

We may consider adding this to integration tests but it is mostly just input
transformation and leaves little room for error.

**Which issue(s) this PR fixes**
Fixes #920

**Special notes for your reviewer**:
You can easily test this locally since it is just client side behavior. Try things like this:
```
# confirm it fails with no stdin input
sonobuoy run -f -

# non-existent file is covered by a unit test
# load data from stdin
sonobuoy gen --e2e-focus "SCHNAKE"|sed 's/SCHNAKE/"\*"/'| sonobuoy run -f -
# wait a second
kubectl get pods -n sonobuoy -o json|jq|grep E2E_FOCUS --context=3

# load a real file
sonobuoy gen --e2e-focus "SCHNAKE"|sed 's/SCHNAKE/"\*"/' > foo
sonobuoy run -f foo
# wait a second
kubectl get pods -n sonobuoy -o json|jq|grep E2E_FOCUS --context=3
```

**Release note**:
```
`sonobuoy run` now accepts input from a file or stdin, meaning you can pipe data from `sonobuoy gen` through tools to manipulate the output and then pipe it back (via stdin or a file) to `sonobuoy run` so that you don't need `kubectl` and can utilize the `--wait` functionality.
```
