### PR TITLE
Use created namespace name during `run --wait`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ stress: sonobuoy
 
 # Integration tests
 int: DOCKER_FLAGS=-v $(KUBECONFIG):/root/.kube/kubeconfig --env KUBECONFIG=/root/.kube/kubeconfig --network host
+int: TESTARGS= $(VERBOSE_FLAG) -timeout 3m
 int: sonobuoy
 	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(INT_TEST)'
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When using a manifest from a file and the `--wait` flag with `run`, a
segfault would happen because the value is retrieved from the
`config.Config` which is part of the `GenConfig` within the `RunConfig`.
When using a file, this config is nil, so an attempt to retrieve the
namespace value resulted in a segfault. Instead, we can capture the
namespace from the objects within the manifest file when they are being
created by the Kubernetes client.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #929

**Special notes for your reviewer**:
I've written added an integration level test to check this and confirmed that the segfault exists before the change and is fixed by it.

**Release note**:
```
Fixed a bug where a segfault would occur with `sonobuoy run --wait` when providing a manifest with a file.
```
