### PR TITLE
Results aggregation should consider the errors directory

### DIFF
--- a/pkg/client/results/reader.go
+++ b/pkg/client/results/reader.go
@@ -44,6 +44,16 @@ const (
 	// Example: plugins/<name>/results
 	ResultsDir = "results/"
 
+	// ErrorsDir defines where in the archive the errors running the plugin get reported.
+	// These are the Sonobuoy reported errors, e.g. failure to start a plugin, timeout, etc.
+	// This is not the appropriate directory for things like test failures.
+	// Example: plugins/<name>/errors
+	ErrorsDir = "errors/"
+
+	// DefaultErrFile is the file name used when Sonobuoy is reporting an error running a plugin.
+	// Is written into the ErrorsDir directory.
+	DefaultErrFile = "errors.json"
+
 	hostsDir                  = "hosts/"
 	namespacedResourcesDir    = "resources/ns/"
 	nonNamespacedResourcesDir = "resources/cluster/"

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/ds-errors-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/ds-errors-01.golden.json
@@ -1,0 +1,64 @@
+{
+"name": "ds-errors-01",
+"status": "failed",
+"items": [
+{
+"name": "node2",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/node2/output.xml"
+},
+"items": [
+{
+"name": "testsuite-001",
+"status": "passed",
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}
+]
+},
+{
+"name": "node1",
+"status": "failed",
+"items": [
+{
+"name": "errors.json",
+"status": "failed",
+"meta": {
+"file": "errors/node1/errors.json"
+},
+"details": {
+"data": "foo",
+"error": "testerr"
+}
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/errors/node1/errors.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/errors/node1/errors.json
@@ -1,0 +1,1 @@
+{"error":"testerr","data":"foo"}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/results/node2/output.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/results/node2/output.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="204" failures="0" time="0.0574002">
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/ds-errors-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/ds-errors-02.golden.json
@@ -1,0 +1,41 @@
+{
+"name": "ds-errors-02",
+"status": "failed",
+"items": [
+{
+"name": "node1",
+"status": "failed",
+"items": [
+{
+"name": "errors.json",
+"status": "failed",
+"meta": {
+"file": "errors/node1/errors.json"
+},
+"details": {
+"data": "foo",
+"error": "testerr"
+}
+}
+]
+},
+{
+"name": "node2",
+"status": "failed",
+"items": [
+{
+"name": "errors.json",
+"status": "failed",
+"meta": {
+"file": "errors/node2/errors.json"
+},
+"details": {
+"data": "foo2",
+"error": "testerr2",
+"node": "node2"
+}
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/errors/node1/errors.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/errors/node1/errors.json
@@ -1,0 +1,1 @@
+{"error":"testerr","data":"foo"}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/errors/node2/errors.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/errors/node2/errors.json
@@ -1,0 +1,1 @@
+{"error":"testerr2","data":"foo2","node":"node2"}

--- a/pkg/client/results/testdata/mockResults/plugins/job-errors/errors/errors.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-errors/errors/errors.json
@@ -1,0 +1,1 @@
+{"error":"testerr","data":"foo"}

--- a/pkg/client/results/testdata/mockResults/plugins/job-errors/job-errors.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-errors/job-errors.golden.json
@@ -1,0 +1,17 @@
+{
+"name": "job-errors",
+"status": "failed",
+"items": [
+{
+"name": "errors.json",
+"status": "failed",
+"meta": {
+"file": "errors/errors.json"
+},
+"details": {
+"data": "foo",
+"error": "testerr"
+}
+}
+]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Whenever the aggregator itself deems that a plugin has failed,
(e.g. pods didnt start, timeouts, etc) then it writes its results
into an errors directory. This should be considered when doing
results aggregation so that they can be resulted as failures.

Otherwise, the plugin is just reported as having 0 results and
having an unknown status even though Sonobuoy may have been the one
to mark it as failure internally.

**Which issue(s) this PR fixes**
Related to #883
Fixes #897

**Special notes for your reviewer**:

**Release note**:
```
When inspecting plugin results (for reporting via `sonobuoy status` and `sonobuoy results`) errors saved in the `<plugin>/errors` directory which are reported by Sonobuoy itself are now considered. This should help make certain failure modes such as timeout more clear.
```
