### PR TITLE
Process all nodes and treat empty status as unknown

### DIFF
--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -420,6 +420,75 @@ func TestAggregateStatus(t *testing.T) {
 				},
 			},
 			expected: StatusUnknown,
+		}, {
+			desc: "Leaf nodes with empty status get changed to unknown",
+			input: []Item{
+				{
+					Name: "unknown node",
+					Items: []Item{
+						{
+							Name: "first leaf no status",
+						},
+					},
+				},
+			},
+			expectedItems: []Item{
+				{
+					Name:   "unknown node",
+					Status: StatusUnknown,
+					Items: []Item{
+						{
+							Name:   "first leaf no status",
+							Status: StatusUnknown,
+						},
+					},
+				},
+			},
+			expected: StatusUnknown,
+		}, {
+			desc: "Processes all nodes even after seeing first failure",
+			input: []Item{
+				{
+					Name: "DS plugin",
+					Items: []Item{
+						{
+							Name: "node1",
+							Items: []Item{
+								{Name: "foo", Status: StatusFailed},
+							},
+						},
+						{
+							Name: "node2",
+							Items: []Item{
+								{Name: "foo", Status: StatusFailed},
+							},
+						},
+					},
+				},
+			},
+			expectedItems: []Item{
+				{
+					Name:   "DS plugin",
+					Status: StatusFailed,
+					Items: []Item{
+						{
+							Name:   "node1",
+							Status: StatusFailed,
+							Items: []Item{
+								{Name: "foo", Status: StatusFailed},
+							},
+						},
+						{
+							Name:   "node2",
+							Status: StatusFailed,
+							Items: []Item{
+								{Name: "foo", Status: StatusFailed},
+							},
+						},
+					},
+				},
+			},
+			expected: StatusFailed,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If a node isn't marked with a status, it should be treated as
being unknown and bubble up accordingly.

**Which issue(s) this PR fixes**
Fixes #900

**Special notes for your reviewer**:

**Release note**:
```
Fixed a bug where some plugins may have reported a final status which was empty to `sonobuoy status` or `sonobuoy results`. These are now treated as "unknown".
```
