### PR TITLE
Add initial CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+version: 2
+jobs:
+  check_go_mod:
+    docker:
+      - image: golang:1.13
+    steps:
+      - checkout
+      - run:
+          name: "Check go module up to date"
+          command: ./scripts/ci/check_go_modules.sh
+
+  check_readme_sync:
+    docker:
+      - image: golang:1.13
+    steps:
+      - checkout
+      - run:
+          name: "Check README in sync"
+          command: ./scripts/ci/check_readme_in_sync.sh
+
+  build:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: "Install kind"
+          command: |
+            curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64 --output kind
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin
+      - run:
+          name: "Create kind cluster"
+          command: |
+            kind create cluster --config kind-config.yaml
+            echo 'export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"' >> $BASH_ENV
+      - run:
+          name: "Build Sonobuoy container image and add to kind cluster"
+          command: make container deploy_kind
+      - run:
+          name: "Run unit and stress tests"
+          command: VERBOSE=true make test stress
+      - run:
+          name: "Run Sonobuoy integration tests"
+          command: |
+            ./scripts/run_integration_tests.sh
+      - run:
+          name: "Start Sonobuoy run, wait, and gather results"
+          command: |
+            ./sonobuoy run --image-pull-policy=IfNotPresent -m Quick --wait
+            tarball=$(./sonobuoy retrieve)
+            ./scripts/ci/check_e2e_tarball.sh $tarball
+            mv $tarball /tmp/sonobuoy-tarball.tar.gz
+      - store_artifacts:
+          path: /tmp/sonobuoy-tarball.tar.gz
+      - run:
+          name: "Upload codecov results"
+          command: bash <(curl -s https://codecov.io/bash)
+
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - check_go_mod
+      - check_readme_sync
+      - build

--- a/scripts/ci/check_e2e_tarball.sh
+++ b/scripts/ci/check_e2e_tarball.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+CI_SCRIPTS_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+DIR=$(cd $CI_SCRIPTS_DIR; cd ../..; pwd)
+
+tarball=$1
+
+set +e
+results=$($DIR/sonobuoy e2e $tarball)
+e2eCode=$?
+echo $results
+set -e
+
+if [ $e2eCode -ne 0 ]; then
+    echo "Error getting results from tarball"
+    $DIR/sonobuoy status
+    $DIR/sonobuoy logs
+    mkdir results; tar xzf $tarball -C results
+
+    echo "Full contents of tarball:"
+    find results
+
+    echo "Printing data on the following files:"
+    find results/plugins -type f
+    find results/plugins -type f \
+      -exec echo Printing file info and contents of {} \; \
+      -exec ls -lah {} \; \
+      -exec cat {} \; \
+      -exec echo \; \
+      -exec echo \;
+    echo "[Exit code of find was: $?]"
+
+    echo "Printing data on the following files:"
+    find results/podlogs -type f
+    find results/podlogs -type f \
+      -exec echo Printing file info and contents of {} \; \
+      -exec ls -lah {} \; \
+      -exec cat {} \; \
+      -exec echo \; \
+      -exec echo \;
+    echo "[Exit code of find was: $?]"
+    exit $e2eCode
+fi
+
+if echo $results | grep --quiet "failed tests: 0"; then
+    echo "|---- Success!"
+else
+    echo "|---- Failure: E2E tests failed"
+    exit 1
+fi

--- a/scripts/ci/check_go_modules.sh
+++ b/scripts/ci/check_go_modules.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+go mod tidy
+
+git_status=$(git status -s)
+if [ -n "$git_status" ]; then
+    echo $git_status
+    echo "go mod tidy modified the git status; did you need add/remove a dependency?"
+    exit 1
+fi

--- a/scripts/ci/check_readme_in_sync.sh
+++ b/scripts/ci/check_readme_in_sync.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPTS_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+$SCRIPTS_DIR/../sync_readme.sh
+
+git_status=$(git status -s)
+if [ -n "$git_status" ]; then
+    echo $git_status
+    echo "scripts/sync_readme.sh modified the git status. If updating the README.md, update the root README.md and run that script."
+    exit 1
+fi


### PR DESCRIPTION
This initial config replicates some of the steps from our TravisCI
config. It introduces a new workflow that contains 3 jobs. It currently
only handles the steps that take place on PR branches:

* Checking that the READMEs are in sync
* Checking the go module state
* Running unit, stress, integration tests and a single Sonobuoy run

It does not yet handle image pushing. That will be addressed in a later
PR.