### PR TITLE
Move image pushing into CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,16 @@ jobs:
           name: "Check README in sync"
           command: ./scripts/ci/check_readme_in_sync.sh
 
-  build:
+  build_and_publish:
     machine:
       enabled: true
-      docker_layer_caching: true
+    steps:
+      - checkout
+      - run: ./scripts/publish.sh
+
+  build_and_test:
+    machine:
+      enabled: true
     steps:
       - checkout
       - run:
@@ -61,8 +67,16 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  checks:
     jobs:
       - check_go_mod
       - check_readme_sync
-      - build
+      - build_and_test
+      - build_and_publish:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Don't fail silently when a step doesn't succeed
+set -e
+
+if [ -z "$CIRCLECI" ]; then
+    echo "this script is intended to be run only on travis" >&2
+    exit 1
+fi
+
+function goreleaser() {
+    curl -sL https://git.io/goreleaser | bash
+}
+
+function image_push() {
+    echo ${DOCKERHUB_TOKEN} | docker login --username sonobuoybot --password-stdin
+    IMAGE_BRANCH="$CIRCLE_BRANCH" make container push
+}
+
+if [ ! -z "$CIRCLE_TAG" ]; then
+    if [ "$(./sonobuoy version --short)" != "$CIRCLE_TAG" ]; then
+        echo "sonobuoy version does not match tagged version!" >&2
+        echo "sonobuoy short version is $(./sonobuoy version --short)" >&2
+        echo "tag is $CIRCLE_TAG" >&2
+        echo "sonobuoy full version info is $(./sonobuoy version)" >&2
+        exit 1
+    fi
+
+    goreleaser --skip-validate
+    image_push
+fi
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
+    image_push
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Moves/updates the travis deploy script to work on circleCI.
 - Added DOCKERHUB_TOKEN via web UI to circleCI
 - runs publishing of images on master branch and on tags like v.*
 - minor change to naming to clarify job purposes

**Which issue(s) this PR fixes**
Ref: #926

**Special notes for your reviewer**:
I tried to use circleCI on my own repo to show this behavior to some extent. You can see here: https://circleci.com/workflow-run/9fdeb6cc-04ae-4e11-9173-bc2f06c14f40 that the publishing waits for the tests to pass. In addition, you can see https://circleci.com/workflow-run/9a9a49a3-5279-40ab-8638-9803a92063e1 doesn't show that the publishing would have occurred at all since it wasn't on the master branch.

**Release note**:
```
NONE
```
