### PR TITLE
Adjust our CircleCI to list tags on required job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ workflows:
     jobs:
       - check_go_mod
       - check_readme_sync
-      - build_and_test
+      - build_and_test:
+          filters:
+            tags:
+              only: /^v.*/
       - build_and_publish:
           requires:
             - build_and_test


### PR DESCRIPTION
Our latest release didnt trigger a tagged release in circleCI; I think this was the cause.