### PR TITLE
Fixing up CI scripts to publish correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
       enabled: true
     steps:
       - checkout
+      - run:
+          name: "Build Sonobuoy to ensure version"
+          command: make build_sonobuoy && sudo mv ./sonobuoy /usr/local/bin
       - run: ./scripts/ci/publish.sh
 
   build_and_test:


### PR DESCRIPTION
Previously the publishing step didn't have the binary to check
the version as it did before.

Builds the binary only since goreleaser and the image pushing logic
will build the other components as needed.