### PR TITLE
Sleep forever after systemd logs plugin finishes

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -257,7 +257,7 @@ func systemdLogsManifest(cfg *GenConfig) *manifest.Manifest {
 			Container: corev1.Container{
 				Name:            "systemd-logs",
 				Image:           "gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest",
-				Command:         []string{"/bin/sh", "-c", "/get_systemd_logs.sh && sleep 3600"},
+				Command:         []string{"/bin/sh", "-c", `/get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset restart"; sleep 3600; done`},
 				ImagePullPolicy: corev1.PullPolicy(cfg.ImagePullPolicy),
 				Env: []corev1.EnvVar{
 					{Name: "CHROOT_DIR", Value: "/node"},

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -54,7 +54,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh && sleep 3600
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -79,7 +79,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh && sleep 3600
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -54,7 +54,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh && sleep 3600
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -42,7 +42,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh && sleep 3600
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -35,7 +35,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh && sleep 3600
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently sleep for 1h after the logs are gathered but some
test runs take multiple hours which leads to this plugin getting
restarted and trying to resubmit logs. This causes confusing messages
in the logs since the original plugin pod is gone and the only one that
exists gets a 409 error from submitting duplicate results.

**Which issue(s) this PR fixes**
Fixes #970

**Special notes for your reviewer**:
Easy to test with our new run-from-stdin capability:
```
go install
sonobuoy gen|sed 's/3600/2/'|sonobuoy run -f -
```

Just a client-side change so no image pushing necessary.

**Release note**:
```
Fixed an issue where the systemd-logs plugin would restart while the e2e tests ran for longer than 1h. This led to confusing messages in the logs.
```
