### PR TITLE
Set OwnerReference on plugin TLS Secret

### DIFF
--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -159,7 +159,7 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort string) error {
 	daemonSet := p.createDaemonSetDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod, progressPort)
 
-	secret, err := p.MakeTLSSecret(cert)
+	secret, err := p.MakeTLSSecret(cert, ownerPod)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't make secret for daemonset plugin %v", p.GetName())
 	}

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -143,7 +143,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort string) error {
 	job := p.createPodDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod, progressPort)
 
-	secret, err := p.MakeTLSSecret(cert)
+	secret, err := p.MakeTLSSecret(cert, ownerPod)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't make secret for Job plugin %v", p.GetName())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We previously modified plugin Pods and DaemonSets to be owned by the
main Sonobuoy pod. When running plugins, we also create a secret for the
TLS certificate used for communication between plugins and the
aggregator pod. This change adds an OwnerReference to this secret so
that it is cleaned up if the main Sonobuoy aggregator pod is deleted.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Special notes for your reviewer**:
Aside from unit testing, I tested this manually by checking that the secret exists before deleting the main Sonobuoy pod, and confirming it is deleted after that pod is deleted.

```
$ kubectl get secrets -n sonobuoy
NAME                                   TYPE                                  DATA   AGE
default-token-r2qd7                    kubernetes.io/service-account-token   3      10s
sonobuoy-plugin-e2e-9d1b7bc465764ac5   kubernetes.io/tls                     2      9s
sonobuoy-serviceaccount-token-59h76    kubernetes.io/service-account-token   3      10s

$ kubectl delete pod sonobuoy -n sonobuoy
pod "sonobuoy" deleted

$ kubectl get secrets -n sonobuoy
NAME                                  TYPE                                  DATA   AGE
default-token-r2qd7                   kubernetes.io/service-account-token   3      111s
sonobuoy-serviceaccount-token-59h76   kubernetes.io/service-account-token   3      111s
```

**Release note**:
```
Sonobuoy now sets the `OwnerReference` on the Secret resource created when running plugins which is used when communicating with the main aggregator pod. This means that if the main aggregator pod is deleted, this Secret will also be deleted.
```
