### PR TITLE
Fix broken e2eplugin link

### DIFF
--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -22,3 +22,6 @@
 - title: Make your own plugins
   key: examples
   destination: examples
+- title: Kubernetes End-To-End Testing Plugin
+  key: e2eplugin
+  destination: e2eplugin


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds `e2eplugin` to the shortlinks so that this page can be
accessed with a URL that does not include a specific version and fixes
the broken link in the main repo README.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
