### PR TITLE
Allow DNS pod selectors to be configured

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -50,6 +50,26 @@ func AddNamespaceFlag(str *string, flags *pflag.FlagSet) {
 	)
 }
 
+// AddDNSNamespaceFlag initialises the dns-namespace flag.
+// The value of this flag is used during preflight checks to determine which namespace to use
+// when looking for the DNS pods.
+func AddDNSNamespaceFlag(str *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		str, "dns-namespace", config.DefaultDNSNamespace,
+		"The namespace to check for DNS pods during preflight checks.",
+	)
+}
+
+// AddDNSPodLabelsFlag initialises the dns-pod-labels flag.
+// The value of this flag is used during preflight checks to determine which labels to use
+// when looking for the DNS pods.
+func AddDNSPodLabelsFlag(str *[]string, flags *pflag.FlagSet) {
+	flags.StringSliceVar(
+		str, "dns-pod-labels", config.DefaultDNSPodLabels,
+		"The label selectors to use for locating DNS pods during preflight checks. Can be specified multiple times or as a comma-separated list.",
+	)
+}
+
 // AddModeFlag initialises a mode flag.
 // The mode is a preset configuration of sonobuoy configuration and e2e configuration variables.
 // Mode can be partially or fully overridden by specifying config, e2e-focus, and e2e-skip.

--- a/cmd/sonobuoy/app/e2e.go
+++ b/cmd/sonobuoy/app/e2e.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/client"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -114,9 +115,12 @@ func e2es(cmd *cobra.Command, args []string) {
 	}
 
 	if !e2eflags.skipPreflight {
-		errs := sonobuoy.PreflightChecks(&client.PreflightConfig{
-			Namespace: e2eflags.namespace,
-		})
+		pcfg := &client.PreflightConfig{
+			Namespace:    runflags.namespace,
+			DNSNamespace: runflags.dnsNamespace,
+			DNSPodLabels: runflags.dnsPodLabels,
+		}
+		errs := sonobuoy.PreflightChecks(pcfg)
 		if len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 	imagepkg "github.com/vmware-tanzu/sonobuoy/pkg/image"
+
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -38,6 +39,8 @@ type genFlags struct {
 	rbacMode                    RBACMode
 	kubecfg                     Kubeconfig
 	namespace                   string
+	dnsNamespace                string
+	dnsPodLabels                []string
 	sonobuoyImage               string
 	kubeConformanceImage        string
 	sshKeyPath                  string
@@ -78,6 +81,8 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	AddShowDefaultPodSpecFlag(&cfg.showDefaultPodSpec, genset)
 
 	AddNamespaceFlag(&cfg.namespace, genset)
+	AddDNSNamespaceFlag(&cfg.dnsNamespace, genset)
+	AddDNSPodLabelsFlag(&cfg.dnsPodLabels, genset)
 	AddSonobuoyImage(&cfg.sonobuoyImage, genset)
 	AddKubeConformanceImage(&cfg.kubeConformanceImage, genset)
 	AddKubeConformanceImageVersion(&cfg.kubeConformanceImageVersion, genset)

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -97,7 +97,12 @@ func submitSonobuoyRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !runflags.skipPreflight {
-		if errs := sbc.PreflightChecks(&client.PreflightConfig{Namespace: runflags.namespace}); len(errs) > 0 {
+		pcfg := &client.PreflightConfig{
+			Namespace:    runflags.namespace,
+			DNSNamespace: runflags.dnsNamespace,
+			DNSPodLabels: runflags.dnsPodLabels,
+		}
+		if errs := sbc.PreflightChecks(pcfg); len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {
 				errlog.LogError(err)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -176,7 +176,9 @@ func (sc *StatusConfig) Validate() error {
 
 // PreflightConfig are the options passed to PreflightChecks.
 type PreflightConfig struct {
-	Namespace string
+	Namespace    string
+	DNSNamespace string
+	DNSPodLabels []string
 }
 
 // Validate checks the config to determine if it is valid.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,9 @@ const (
 	DefaultQueryBurst = 50
 	// DefaultProgressUpdatesPort is the port on which the Sonobuoy worker will listen for status updates from its plugin.
 	DefaultProgressUpdatesPort = "8099"
+
+	// DefaultDNSNamespace is the namespace where the DNS pods for the cluster are found.
+	DefaultDNSNamespace = "kube-system"
 )
 
 var (
@@ -111,6 +114,12 @@ var (
 		"storageclasses",
 		"validatingwebhookconfigurations",
 		"volumeattachments",
+	}
+
+	// DefaultDNSPodLabels are the label selectors that are used to locate the DNS pods in the cluster.
+	DefaultDNSPodLabels = []string{
+		"k8s-app=kube-dns",
+		"k8s-app=coredns",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The preflight checks for Sonobuoy assume the namespace and labels of the
DNS pods. Although the preflight checks can be skipped, some users may
want to still run these checks and ensure that they pass before testing.
To allow this, this change introduces two new flags that are applied to
the `PreflightConfig` so that the namespace and labels to use for
finding the DNS pods can be configured.

The two new flags are: `--dns-namespace` and `--dns-pod-labels`.
The default values are the values that were previously being used so
this does not impact existing users.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #975 

**Special notes for your reviewer**:
I've verified that this change works with an OpenShift 4.x cluster by creating one locally using [CRC](https://code-ready.github.io/crc/).

**Release note**:
```
The namespace and label selectors used by Sonobuoy to find the DNS pods during the preflight checks can now be customised using the flags `--dns-namespace` and `--dns-pod-labels`.
```
