### PR TITLE
Allow plugins to be specified via a URL

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -311,7 +311,7 @@ func AddSSHUserFlag(user *string, flags *pflag.FlagSet) {
 // AddPluginSetFlag adds the flag for gen/run which keeps track of which plugins
 // to run and loads them from local files if necessary.
 func AddPluginSetFlag(p *pluginList, flags *pflag.FlagSet) {
-	flags.VarP(p, "plugin", "p", "Which plugins to run. Can either point to a local file or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.")
+	flags.VarP(p, "plugin", "p", "Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.")
 }
 
 // AddPluginEnvFlag adds the flag for gen/run which keeps track of which plugins

--- a/cmd/sonobuoy/app/pluginList.go
+++ b/cmd/sonobuoy/app/pluginList.go
@@ -17,15 +17,20 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -74,18 +79,30 @@ func (p *pluginList) Set(str string) error {
 	case pluginSystemdLogs:
 		p.DynamicPlugins = append(p.DynamicPlugins, str)
 	default:
-		finfo, err := os.Stat(str)
-		if err != nil {
-			return errors.Wrapf(err, "unable to stat %q", str)
+		if isURL(str) {
+			return p.loadSinglePluginFromURL(str)
 		}
-
-		if finfo.IsDir() {
-			return p.loadPluginsDir(str)
-		}
-		return p.loadSinglePlugin(str)
+		return p.loadPluginsFromFilesystem(str)
 	}
 
 	return nil
+}
+
+func isURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func (p *pluginList) loadPluginsFromFilesystem(str string) error {
+	finfo, err := os.Stat(str)
+	if err != nil {
+		return errors.Wrapf(err, "unable to stat %q", str)
+	}
+
+	if finfo.IsDir() {
+		return p.loadPluginsDir(str)
+	}
+	return p.loadSinglePluginFromFile(str)
 }
 
 // loadPluginsDir loads every plugin in the given directory. It does not traverse recursively
@@ -99,7 +116,7 @@ func (p *pluginList) loadPluginsDir(dirpath string) error {
 
 	for _, file := range files {
 		if !file.IsDir() && strings.HasSuffix(file.Name(), fileExtensionYAML) {
-			if err := p.loadSinglePlugin(filepath.Join(dirpath, file.Name())); err != nil {
+			if err := p.loadSinglePluginFromFile(filepath.Join(dirpath, file.Name())); err != nil {
 				return errors.Wrapf(err, "failed to load plugin in file %q", file.Name())
 			}
 		}
@@ -108,16 +125,42 @@ func (p *pluginList) loadPluginsDir(dirpath string) error {
 	return nil
 }
 
-// loadSinglePlugin loads a single plugin located at the given path.
-func (p *pluginList) loadSinglePlugin(filepath string) error {
-	b, err := ioutil.ReadFile(filepath)
+// loadSinglePluginFromURL loads a single plugin located at the given path.
+func (p *pluginList) loadSinglePluginFromURL(url string) error {
+	c := http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := c.Get(url)
+	if err != nil {
+		return errors.Wrapf(err, "unable to GET URL %q", url)
+	}
+	if resp.StatusCode > 399 {
+		return fmt.Errorf("unexpected HTTP response code %v", resp.StatusCode)
+	}
+
+	return errors.Wrapf(p.loadSinglePlugin(resp.Body), "loading plugin from URL %q", url)
+}
+
+// loadSinglePluginFromFile loads a single plugin located at the given path.
+func (p *pluginList) loadSinglePluginFromFile(filepath string) error {
+	f, err := os.Open(filepath)
 	if err != nil {
 		return errors.Wrapf(err, "unable to read file %q", filepath)
+	}
+	return errors.Wrapf(p.loadSinglePlugin(f), "loading plugin from file %q", filepath)
+}
+
+// loadSinglePlugin reads the data from the reader and loads the plugin.
+func (p *pluginList) loadSinglePlugin(r io.ReadCloser) error {
+	defer r.Close()
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Wrap(err, "failed to read data for plugin")
 	}
 
 	newPlugin, err := loadManifest(b)
 	if err != nil {
-		return errors.Wrapf(err, "failed to load plugin file %q", filepath)
+		return errors.Wrap(err, "failed to load plugin")
 	}
 
 	p.StaticPlugins = append(p.StaticPlugins, newPlugin)


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently allow loading plugins from the local file system
but for sharing of plugins it makes sense to allow users to
specify a URL.

**Which issue(s) this PR fixes**
Fixes #986

**Special notes for your reviewer**:

**Release note**:
```
The `--plugin` flag now supports URLs in addition to paths to local files or directories.
```
