### PR TITLE
Update to log logic in order to stream from new containers as created

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624190245-7f2218787638 h1:uIfBkD8gLczr4XDgYpt/qJYds2YJwZRNw4zs7wSnNhk=
 golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/pkg/client/logs.go
+++ b/pkg/client/logs.go
@@ -23,14 +23,18 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
 
 const (
 	bufSize = 4096
+
+	// maxBackoffSeconds is the maximum time to backoff when waiting for pods to startup. Prevents
+	// unhelpfully large noop periods.
+	maxBackoffSeconds = 32
 )
 
 // Reader provides an io.Reader interface to a channel of bytes. The first error
@@ -41,12 +45,12 @@ const (
 type Reader struct {
 	bytestream chan []byte
 	errc       chan error
-	done       chan struct{}
 
 	// Used for when one message is too large for the input buffer
 	// TODO(chuckha) consider alternative data structures here
 	overflowBuffer []byte
 	err            error
+	empty          bool
 }
 
 // NewReader returns a configured Reader.
@@ -64,11 +68,6 @@ func NewReader(bytestream chan []byte, errc chan error) *Reader {
 // Read manages the message overflow ensuring no bytes are missed.
 // If an error is set on the reader it will return the error immediately.
 func (r *Reader) Read(p []byte) (int, error) {
-	// Always return the error if it is set.
-	if r.err != nil {
-		return 0, r.err
-	}
-
 	// Send any overflow before grabbing new messages.
 	if len(r.overflowBuffer) > 0 {
 		// If we need to chunk it, copy as much as we can and reduce the overflow buffer.
@@ -84,20 +83,50 @@ func (r *Reader) Read(p []byte) (int, error) {
 		return n, nil
 	}
 
-	data, ok := <-r.bytestream
-	// If the bytestream is done then save the error for future calls to Read.
-	if !ok {
-		r.err, ok = <-r.errc
-		// Assume EOF if error channel is closed.
-		if r.err == nil && !ok {
+	// Return the error if set only if byte channel is empty.
+	if r.err != nil && r.empty {
+		return 0, r.err
+	}
+
+	// Be sure that we are draining any errors put on the errc and unblock senders.
+	var err error
+	var data []byte
+	var ok bool
+	select {
+	case err, ok = <-r.errc:
+		// Treat the errors as data as well. This ensures that the user reading the messages
+		// is aware of the errors as they happen and not only after all messages are processed.
+		// This is important in the case of tailing logs where one stream may never finish at all.
+		if err != nil && err != io.EOF {
+			data = []byte(fmt.Sprint(err))
+		}
+
+		// Save only the first error. Assume io.EOF if closed/nil.
+		switch {
+		case err != nil:
+			r.err = err
+		case err == nil || !ok:
 			r.err = io.EOF
 		}
-		if r.err != nil {
-			return 0, r.err
+
+		// If the channel is closed, set to nil to avoid reading this channel again.
+		if !ok {
+			r.errc = nil
+		}
+	case data, ok = <-r.bytestream:
+		if !ok {
+			r.empty = true
+			// Ensure we don't choose this path again in the select.
+			r.bytestream = nil
 		}
 	}
 
-	// TODO(chuckha) this code and the code above in the overflow buffer is identical. Might be an indication of a cleaner way to do this.
+	// Avoid the case where a channel was closed and we don't have data to process. This would end up returning
+	// (0, nil) which is discouraged but also ends up leaving `p` unmodified which is against the documentation
+	// of io.Reader.
+	if len(data) == 0 {
+		return r.Read(p)
+	}
 
 	// The incoming data is bigger than size of the remaining size of the buffer. Save overflow data for next read.
 	if len(data) > len(p) {
@@ -111,30 +140,65 @@ func (r *Reader) Read(p []byte) (int, error) {
 	return len(data), nil
 }
 
-// getPodsForLogs retrieves the pods to stream logs from. If a plugin name has been provided, retrieve the pods with
+// getPodsToStreamLogs retrieves the pods to stream logs from. If a plugin name has been provided, retrieve the pods with
 // only the plugin label matching that plugin name. If no pods are found, or no plugin has been specified, retrieve
-// all pods within the namespace.
-func getPodsForLogs(client kubernetes.Interface, cfg *LogConfig) (*v1.PodList, error) {
+// all pods within the namespace. It will immediately return an error if unabel to list pods, but will otherwise
+// add pods onto the channel in a separate go routine so that this method does not block. It closes the pod channel once
+// all the pods have been reported.
+func getPodsToStreamLogs(client kubernetes.Interface, cfg *LogConfig, podCh chan *v1.Pod) error {
+	listOptions := metav1.ListOptions{}
 	if cfg.Plugin != "" {
 		selector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "sonobuoy-plugin", cfg.Plugin)
-		options := metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)}
-		pods, err := client.CoreV1().Pods(cfg.Namespace).List(options)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to list pods")
-		}
-
-		if len(pods.Items) != 0 {
-			return pods, nil
-		}
-
-		logrus.Warningf("failed to find pods for plugin %q, defaulting to all pods", cfg.Plugin)
+		listOptions = metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)}
 	}
 
-	pods, err := client.CoreV1().Pods(cfg.Namespace).List(metav1.ListOptions{})
+	podList, err := client.CoreV1().Pods(cfg.Namespace).List(listOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list pods")
+		return errors.Wrap(err, "failed to list pods")
 	}
-	return pods, nil
+
+	go func() {
+		for _, p := range podList.Items {
+			podCh <- &p
+		}
+		close(podCh)
+	}()
+
+	return nil
+}
+
+// watchPodsToStreamLogs creates a watch for the desired pods and, as it gets events for new pods will add them onto the pod channel.
+//  If a plugin name has been provided, retrieve the pods with only the plugin label matching that plugin name. If no pods are found,
+// or no plugin has been specified, retrieve all pods within the namespace. It will return an error if unable to create the watcher
+// but will continue to add pods to the channel in a separate go routine.
+func watchPodsToStreamLogs(client kubernetes.Interface, cfg *LogConfig, podCh chan *v1.Pod) error {
+	listOptions := metav1.ListOptions{}
+	if cfg.Plugin != "" {
+		selector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "sonobuoy-plugin", cfg.Plugin)
+		listOptions = metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)}
+	}
+
+	watcher, err := client.CoreV1().Pods(cfg.Namespace).Watch(listOptions)
+	if err != nil {
+		return errors.Wrap(err, "failed to watch pods")
+	}
+	ch := watcher.ResultChan()
+
+	go func() {
+		for {
+			select {
+			case v := <-ch:
+				if v.Type == watch.Added && v.Object != nil {
+					switch t := v.Object.(type) {
+					case *v1.Pod:
+						podCh <- t
+					default:
+					}
+				}
+			}
+		}
+	}()
+	return nil
 }
 
 // LogReader configures a Reader that provides an io.Reader interface to a merged stream of logs from various containers.
@@ -151,45 +215,57 @@ func (s *SonobuoyClient) LogReader(cfg *LogConfig) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	pods, err := getPodsForLogs(client, cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// We must make sure the error channel has capacity enough so that it never blocks
-	// in case of early exits.
-	numContainers := 0
-	for _, pod := range pods.Items {
-		numContainers += len(pod.Spec.Containers)
-	}
-
-	errc := make(chan error, numContainers)
-	agg := make(chan *message)
+	podCh := make(chan *v1.Pod)
 	var wg sync.WaitGroup
 
-	// TODO(chuckha) if we get an error back that the container is still creating maybe we could retry?
-	for _, pod := range pods.Items {
-		for _, container := range pod.Spec.Containers {
-			wg.Add(1)
-			ls := &logStreamer{
-				ns:        pod.Namespace,
-				pod:       pod.Name,
-				container: container.Name,
-				errc:      errc,
-				logc:      agg,
-				logOpts: &v1.PodLogOptions{
-					Container: container.Name,
-					Follow:    cfg.Follow,
-				},
-				client: client,
-			}
-
-			go func(w *sync.WaitGroup, ls *logStreamer) {
-				defer w.Done()
-				ls.stream()
-			}(&wg, ls)
+	if cfg.Follow {
+		// Extra waitGroup item ensures we just keep processing forever.
+		wg.Add(1)
+		if err := watchPodsToStreamLogs(client, cfg, podCh); err != nil {
+			return nil, errors.Wrap(err, "failed to watch for new pods")
 		}
+	} else {
+		if err := getPodsToStreamLogs(client, cfg, podCh); err != nil {
+			return nil, errors.Wrap(err, "failed to list pods")
+		}
+	}
+
+	errc := make(chan error)
+	agg := make(chan *message)
+
+	drainPodChannelAndStartStreaming := func() {
+		for pod := range podCh {
+			for _, container := range pod.Spec.Containers {
+				wg.Add(1)
+				ls := &logStreamer{
+					ns:        pod.Namespace,
+					pod:       pod.Name,
+					container: container.Name,
+					errc:      errc,
+					logc:      agg,
+					logOpts: &v1.PodLogOptions{
+						Container: container.Name,
+						Follow:    cfg.Follow,
+					},
+					client: client,
+				}
+
+				go func(w *sync.WaitGroup, ls *logStreamer) {
+					defer w.Done()
+					ls.stream()
+				}(&wg, ls)
+			}
+		}
+	}
+
+	// When following logs we will never drain the channel of pods since we are always waiting for new ones. So
+	// just put that into a go routine which will start them as soon as possible. If not following pods, just
+	// ensure we start streaming logs from all the existing pods before waiting for them to finish up or else you
+	// introduce a race.
+	if cfg.Follow {
+		go drainPodChannelAndStartStreaming()
+	} else {
+		drainPodChannelAndStartStreaming()
 	}
 
 	// Cleanup when finished.
@@ -257,6 +333,9 @@ func (l *logStreamer) waitForContainerRunning() error {
 		fmt.Printf("container %v, is not running, will retry streaming logs in %v seconds\n", l.podName(), backoffSeconds)
 		time.Sleep(backoffSeconds)
 		backoffSeconds *= 2
+		if backoffSeconds > maxBackoffSeconds*time.Second {
+			backoffSeconds = maxBackoffSeconds * time.Second
+		}
 	}
 }
 
@@ -265,10 +344,11 @@ func (l *logStreamer) stream() {
 	if l.logOpts.Follow {
 		err := l.waitForContainerRunning()
 		if err != nil {
-			l.errc <- errors.Wrapf(err, "failed to waiting for container [%v] in pod [%s/%s] to start running", l.container, l.ns, l.pod)
+			l.errc <- errors.Wrapf(err, "failed to wait for container [%v] in pod [%s/%s] to start running", l.container, l.ns, l.pod)
 			return
 		}
 	}
+
 	req := l.client.CoreV1().Pods(l.ns).GetLogs(l.pod, l.logOpts)
 	readCloser, err := req.Stream()
 	if err != nil {


### PR DESCRIPTION
 - Adds a method which adds a watch for new pods in the target namespace
 - Removes fallback/retry logic which mutates the query from a specific
plugin to all plugins.
 - Adds a ceiling for the max polling time when backing off due to a container
not being in a running state
 - Adjusts tests as necessary

Fixes #703

**Special notes for your reviewer**:
A simple way to test this is to do:
```
sonobuoy run && sonobuoy logs -f
```

You'll now see that the e2e logs get streamed when the container is created; that would not happen with the older logic.

**Release note**:
```
Sonobuoy will now begin tailing logs from new containers as they are created while running `sonobuoy logs -f`
```
