### PR TITLE
Publish 32-bit and arm64 clients

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,15 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm64
+    - 386
+  ignore:
+    - goos: darwin
+      goarch: 386
+    - goos: darwin
+      goarch: arm64
+    - goos: windows
+      goarch: arm64
   ldflags: -s -w -X github.com/vmware-tanzu/sonobuoy/pkg/buildinfo.Version=v{{.Version}} -X github.com/vmware-tanzu/sonobuoy/pkg/buildinfo.GitSHA={{.FullCommit}}
 archive:
   format: tar.gz


### PR DESCRIPTION
Adjustment to our goreleaser configuration so that we publish the
 - 32-bit Windows client
 - 32-bit Linux client
 - 64-bit Arm64 client

That means we now publish 6 clients; the above along with:
 - 64-bit Windows
 - 64-bit Linux
 - 64-bit Darwin

I don't think the other combinations of goos/goarch make sense to publish.

Fixes #1005

**Special notes for your reviewer**:
I just locally did `GOOS=xyz GOARCH=abc go install` to ensure those clients all build.

There isn't a history of really supporting the 32bit clients but if this is the cost (a tiny update to the goreleaser) and an occasional ticket then I think it is fine to publish it to make consuming it easier.

**Release note**:
```
Sonobuoy will now publish 32-bit Windows/Linux clients and arm64 clients on its Github release page.
```
