### PR TITLE
Default to enableing progress updates from E2E plugin

### DIFF
--- a/pkg/client/gen_internal_test.go
+++ b/pkg/client/gen_internal_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+)
+
+func TestE2EImageSupportsProgress(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		input    string
+		expected bool
+	}{
+		{
+			desc:  "tag not semver wont support it",
+			input: "someimage:sometag",
+		}, {
+			desc:  "v1.16 not supported",
+			input: "someimage:v1.16.99",
+		}, {
+			desc:     "tag with v prefix is OK",
+			input:    "someimage:v1.17.0",
+			expected: true,
+		}, {
+			desc:     "tag without v prefix is OK",
+			input:    "someimage:1.17.0",
+			expected: true,
+		}, {
+			desc:     "tag with metadata is ok",
+			input:    "someimage:v1.17.0+meta",
+			expected: true,
+		}, {
+			desc:     "future versions ok",
+			input:    "someimage:v1.19.1",
+			expected: true,
+		}, {
+			desc:     "prerelease of v1.17 is ok",
+			input:    "someimage:v1.17.0-beta",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := e2eImageSupportsProgress(tc.input)
+			if got != tc.expected {
+				t.Errorf("Expected %v but got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -355,6 +355,36 @@ func TestGenerateManifestGolden(t *testing.T) {
 				},
 			},
 			goldenFile: filepath.Join("testdata", "use-existing-pod-spec.golden"),
+		}, {
+			name: "Conformance images >= v1.17 support progress",
+			inputcm: &client.GenConfig{
+				E2EConfig:            &client.E2EConfig{},
+				DynamicPlugins:       []string{"e2e"},
+				KubeConformanceImage: "some-image:v1.17.0",
+			},
+			goldenFile: filepath.Join("testdata", "e2e-progress.golden"),
+		}, {
+			name: "ProgressUpdatesPort is customizable for e2e",
+			inputcm: &client.GenConfig{
+				E2EConfig:            &client.E2EConfig{},
+				DynamicPlugins:       []string{"e2e"},
+				KubeConformanceImage: "some-image:v1.17.0",
+				Config: &config.Config{
+					ProgressUpdatesPort: "1234",
+				},
+			},
+			goldenFile: filepath.Join("testdata", "e2e-progress-custom-port.golden"),
+		}, {
+			name: "Conformance images >= v1.17 will not override E2E_EXTRA_ARGS if specified by user",
+			inputcm: &client.GenConfig{
+				E2EConfig:            &client.E2EConfig{},
+				DynamicPlugins:       []string{"e2e"},
+				KubeConformanceImage: "some-image:v1.17.0",
+				PluginEnvOverrides: map[string]map[string]string{
+					"e2e": {"E2E_EXTRA_ARGS": "user-defined"},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "e2e-progress-vs-user-defined.golden"),
 		},
 	}
 

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -1,0 +1,118 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":null,"FieldSelectors":null,"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":"","ProgressUpdatesPort":"1234"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      - name: E2E_EXTRA_ARGS
+        value: --progress-report-url=http://localhost:1234/progress
+      image: some-image:v1.17.0
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -1,0 +1,118 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":null,"FieldSelectors":null,"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_EXTRA_ARGS
+        value: user-defined
+      - name: E2E_FOCUS
+      - name: E2E_PARALLEL
+      - name: E2E_SKIP
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      image: some-image:v1.17.0
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -1,0 +1,118 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":null,"FieldSelectors":null,"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      - name: E2E_EXTRA_ARGS
+        value: --progress-report-url=http://localhost:8099/progress
+      image: some-image:v1.17.0
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP


### PR DESCRIPTION
As of v1.17 the Kubernetes E2E test image will support progress
updates if the URL is specified.

Fixes #992 

**Special notes for your reviewer**:
Do the following to test:

```
$ go install && sonobuoy run --kube-conformance-image-version=v1.17.0-beta.2
```

It doesn't matter that your cluster may not be that version, since we are targeting that version of the image it will work. Likewise, you can do `sonobuoy gen` with that same option to see the YAML as well.

After starting the run, just poll against `sonobuoy status --json | jq` to confirm that you're getting progress updates.

Note: This will _not_ work if you are specifying the exact image via digest, e.g. `gcr.io/google-containers/conformance@sha256:8f55d97d42690532e44068b6db98051bc3782c916987cff8db3d43447b09a94e` . I think this is just a limitation that we will live with and is OK. Users that want to do that can always specify then env var themselves.

**Release note**:
```
If targeting v1.17 clusters and above, the e2e plugin will not provide the necessary logic in order to enable progress updates from the plugin. At the current time, you can see progress via `sonobuoy status --json`.
```
