### PR TITLE
Add command to output default image registry config

### DIFF
--- a/cmd/sonobuoy/app/gen_image_repo_config.go
+++ b/cmd/sonobuoy/app/gen_image_repo_config.go
@@ -1,0 +1,79 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
+	"github.com/vmware-tanzu/sonobuoy/pkg/image"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// NewCmdGenImageRepoConfig creates the `default-image-config` subcommand for `gen`
+// which will print out the default image registry config for the E2E tests which is
+// used with the `images` and `run` command.
+func NewCmdGenImageRepoConfig() *cobra.Command {
+	var cfg Kubeconfig
+	cmd := &cobra.Command{
+		Use:   "default-image-config",
+		Short: "Generates the default image registry config for the e2e plugin",
+		Run: func(cmd *cobra.Command, args []string) {
+			s, err := defaultImageRegConfig(&cfg)
+			if err != nil {
+				errlog.LogError(err)
+				os.Exit(1)
+			}
+			fmt.Println(string(s))
+		},
+		Args: cobra.NoArgs,
+	}
+
+	genPluginSet := pflag.NewFlagSet("default-image-config", pflag.ExitOnError)
+	AddKubeconfigFlag(&cfg, genPluginSet)
+	cmd.Flags().AddFlagSet(genPluginSet)
+
+	return cmd
+}
+
+func defaultImageRegConfig(cfg *Kubeconfig) ([]byte, error) {
+	sbc, err := getSonobuoyClientFromKubecfg(*cfg)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "could not create sonobuoy client")
+	}
+
+	version, err := sbc.Version()
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "couldn't get Kubernetes version")
+	}
+
+	registries, err := image.GetDefaultImageRegistries(version)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "couldn't get image registries for version")
+	}
+
+	d, err := yaml.Marshal(&registries)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "couldn't marshal registry information")
+	}
+	return d, nil
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -20,8 +20,8 @@ import (
 	"flag"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
-	"github.com/spf13/cobra"
 
+	"github.com/spf13/cobra"
 	"k8s.io/klog"
 )
 
@@ -42,6 +42,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	gen := NewCmdGen()
 	gen.AddCommand(NewCmdGenPluginDef())
 	gen.AddCommand(NewCmdGenConfig())
+	gen.AddCommand(NewCmdGenImageRepoConfig())
 	cmds.AddCommand(gen)
 
 	cmds.AddCommand(NewCmdLogs())

--- a/pkg/image/manifest_test.go
+++ b/pkg/image/manifest_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetDefaultImageRegistryVersionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		error   bool
+		expect  string
+	}{
+		{
+			name:    "Non valid version results in error",
+			version: "not-a-valid-version",
+			error:   true,
+			expect:  "\"not-a-valid-version\" is invalid",
+		},
+		{
+			name:    "v1.13 is valid",
+			version: "v1.13.0",
+			error:   false,
+		},
+		{
+			name:    "v1.14 is valid",
+			version: "v1.14.0",
+			error:   false,
+		},
+		{
+			name:    "v1.15 is valid",
+			version: "v1.15.0",
+			error:   false,
+		},
+		{
+			name:    "v1.16 is valid",
+			version: "v1.16.0",
+			error:   false,
+		},
+		{
+			name:    "v1.12 is not valid",
+			version: "v1.12.0",
+			error:   true,
+			expect:  "No matching configuration for k8s version: 1.12",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := GetDefaultImageRegistries(tc.version)
+			if tc.error && err == nil {
+				t.Fatal("expected error, got nil")
+			} else if !tc.error && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			} else if tc.error && !strings.Contains(err.Error(), tc.expect) {
+				t.Fatalf("expected error to contain %q, got %v", tc.expect, err.Error())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the subcommand `default-image-config` to `gen` to output the
default image registry config used with the `images` and `run` commands.
It will generate the config based on the version of Kubernetes that is
configured for use.

This simplifies the process for users as the registries for the E2E
tests differ for different versions of Kubernetes.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1010

**Special notes for your reviewer**:
I included some tests for checking that the version verification worked however I didn't write tests to check the resulting registry lists as these seemed to just duplicate the code. I'm happy to add them though if it seems worth it.

**Release note**:
```
Sonobuoy can now output the default configuration for the registries used by the `e2e` plugin using the new command `gen default-image-config`. This will output the default configuration for the version of Kubernetes that is being tested. This configuration is required for using the `images` command.
```