### PR TITLE
Add FAQ to shortlinks

### DIFF
--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -25,3 +25,6 @@
 - title: Kubernetes End-To-End Testing Plugin
   key: e2eplugin
   destination: e2eplugin
+- title: Frequently Asked Questions
+  key: faq
+  destination: faq


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the FAQ page to the shortlinks so that it can be accessed
without needing to specify a version in the URL.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
