### PR TITLE
Process JUnit error field

### DIFF
--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -157,6 +157,10 @@ func TestPostProcessPlugin(t *testing.T) {
 			desc:   "Errors can contain complex structured data",
 			key:    "job-complex-err",
 			plugin: getPlugin("job-complex-err", "job", "junit", []string{}),
+		}, {
+			desc:   "tmp name",
+			key:    "job-junit-falsepositive",
+			plugin: getPlugin("job-junit-falsepositive", "job", "junit", []string{}),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/job-junit-falsepositive.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/job-junit-falsepositive.golden.json
@@ -1,0 +1,28 @@
+{
+"name": "job-junit-falsepositive",
+"status": "failed",
+"items": [
+{
+"name": "output.xml",
+"status": "failed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "Alertmanager - Alertmanager statefuleset(executeK8sTests())",
+"status": "failed",
+"items": [
+{
+"name": "Alertmanager - Alertmanager statefuleset(executeK8sTests",
+"status": "failed",
+"details": {
+"error": "Alertmanager statefuleset - Connection refused (Connection refused) org.opentest4j.AssertionFailedError: Alertmanager statefuleset - Connection refused (Connection refused)\n\tat com.cg.k8s.tests.client.K8sPlatformTests.test(K8sPlatformTests.java:163)\n\tat com.cg.k8s.tests.client.K8sPlatformTests.lambda$0(K8sPlatformTests.java:94)\n\tat java.util.Optional.ifPresent(Optional.java:159)\n\tat java.util.ArrayList.forEach(ArrayList.java:1257)\n\tat java.util.ArrayList.forEach(ArrayList.java:1257)\n\tat com.cg.k8s.tests.client.RunTests.main(RunTests.java:41)"
+}
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/results/global/output.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/results/global/output.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="1" hostname="cgogineni" name="Alertmanager - Alertmanager statefuleset(executeK8sTests())" skipped="0" tests="1" time="0.005" timestamp="2019-12-03T17:53:38">
+  <properties />
+  <testcase classname="com.cg.k8s.tests.reports.JUnitResultFormatterAsRunListener$DescriptionAsTest" name="Alertmanager - Alertmanager statefuleset(executeK8sTests" time="0.005">
+    <error message="Alertmanager statefuleset - Connection refused (Connection refused)" type="org.opentest4j.AssertionFailedError">org.opentest4j.AssertionFailedError: Alertmanager statefuleset - Connection refused (Connection refused)
+	at com.cg.k8s.tests.client.K8sPlatformTests.test(K8sPlatformTests.java:163)
+	at com.cg.k8s.tests.client.K8sPlatformTests.lambda$0(K8sPlatformTests.java:94)
+	at java.util.Optional.ifPresent(Optional.java:159)
+	at java.util.ArrayList.forEach(ArrayList.java:1257)
+	at java.util.ArrayList.forEach(ArrayList.java:1257)
+	at com.cg.k8s.tests.client.RunTests.main(RunTests.java:41)
+</error>
+  </testcase>
+  <system-out><![CDATA[Request method:	GET
+Request URI:	http://localhost:8001/apis/apps/v1/namespaces/monitoring/statefulsets/alertmanager-main/status
+Proxy:			<none>
+...
+]]></system-out>
+  <system-err><![CDATA[java.net.ConnectException: Connection refused (Connection refused)
+	at java.net.PlainSocketImpl.socketConnect(Native Method)
+	...
+	...
+]]></system-err>
+</testsuite>


### PR DESCRIPTION
**What this PR does / why we need it**:
If the test fails to run properly we need to record it as a failure
for our purposes.

**Which issue(s) this PR fixes**
Fixes #1025

**Special notes for your reviewer**:
Unit test covers the failure in the originating issue.

**Release note**:
```
Fixed an issue where the <error ... > field of JUnit test cases was not parsed. These now get reported via Sonobuoy as failures.
```
