### PR TITLE
Tag Items with metadata about the type if item (e.g. node/file/etc)

### DIFF
--- a/pkg/client/results/junit.go
+++ b/pkg/client/results/junit.go
@@ -174,9 +174,12 @@ func junitProcessFile(pluginDir, currentFile string) (Item, error) {
 	}
 
 	resultObj := Item{
-		Name:     filepath.Base(currentFile),
-		Status:   StatusUnknown,
-		Metadata: map[string]string{"file": relPath},
+		Name:   filepath.Base(currentFile),
+		Status: StatusUnknown,
+		Metadata: map[string]string{
+			metadataFileKey: relPath,
+			metadataTypeKey: metadataTypeFile,
+		},
 	}
 
 	infile, err := os.Open(currentFile)

--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -57,6 +57,18 @@ const (
 	// PostProcessedResultsFile is the name of the file we create when doing
 	// postprocessing on the plugin results.
 	PostProcessedResultsFile = "sonobuoy_results.yaml"
+
+	// metadataFileKey is the key used in an Item's metadata field when the Item is
+	// representing the a file summary (and its leaf nodes are individual tests or suites).
+	metadataFileKey = "file"
+
+	// metadataTypeKey is the key used in an Item's metadata field when describing what type
+	// of entry in the tree it is. Currently we just tag summaries, files, and nodes.
+	metadataTypeKey = "type"
+
+	metadataTypeNode    = "node"
+	metadataTypeFile    = "file"
+	metadataTypeSummary = "summary"
 )
 
 // ResultFormat constants are the supported values for the resultFormat field
@@ -211,7 +223,8 @@ func processNodesWithProcessor(p plugin.Interface, baseDir, dir string, processo
 		}
 		nodeName := filepath.Base(nodeDirInfo.Name())
 		nodeItem := Item{
-			Name: nodeName,
+			Name:     nodeName,
+			Metadata: map[string]string{metadataTypeKey: metadataTypeNode},
 		}
 		items, err := processDir(p, pdir, filepath.Join(dir, nodeName), processor, selector)
 		nodeItem.Items = items
@@ -235,7 +248,8 @@ func processPluginWithProcessor(p plugin.Interface, baseDir string, processor po
 
 	_, isDS := p.(*daemonset.Plugin)
 	results := Item{
-		Name: p.GetName(),
+		Name:     p.GetName(),
+		Metadata: map[string]string{metadataTypeKey: metadataTypeSummary},
 	}
 
 	if isDS {

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/ds-errors-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-01/ds-errors-01.golden.json
@@ -1,16 +1,23 @@
 {
 "name": "ds-errors-01",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "node2",
 "status": "passed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/node2/output.xml"
+"file": "results/node2/output.xml",
+"type": "file"
 },
 "items": [
 {
@@ -46,6 +53,9 @@
 {
 "name": "node1",
 "status": "failed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "testerr",

--- a/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/ds-errors-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-errors-02/ds-errors-02.golden.json
@@ -1,10 +1,16 @@
 {
 "name": "ds-errors-02",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "node1",
 "status": "failed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "testerr",
@@ -22,6 +28,9 @@
 {
 "name": "node2",
 "status": "failed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "testerr2",

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-01/ds-junit-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-01/ds-junit-01.golden.json
@@ -1,16 +1,23 @@
 {
 "name": "ds-junit-01",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "passed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-02/ds-junit-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-02/ds-junit-02.golden.json
@@ -1,16 +1,23 @@
 {
 "name": "ds-junit-02",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "failed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {
@@ -45,7 +52,8 @@
 "name": "output2.xml",
 "status": "failed",
 "meta": {
-"file": "results/global/output2.xml"
+"file": "results/global/output2.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-03/ds-junit-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-03/ds-junit-03.golden.json
@@ -1,16 +1,23 @@
 {
 "name": "ds-junit-03",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "failed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {
@@ -45,7 +52,8 @@
 "name": "output2.xml",
 "status": "failed",
 "meta": {
-"file": "results/global/output2.xml"
+"file": "results/global/output2.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-01/ds-raw-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-01/ds-raw-01.golden.json
@@ -1,10 +1,16 @@
 {
 "name": "ds-raw-01",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "passed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-02/ds-raw-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-02/ds-raw-02.golden.json
@@ -1,10 +1,16 @@
 {
 "name": "ds-raw-02",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "passed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-03/ds-raw-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-03/ds-raw-03.golden.json
@@ -1,10 +1,16 @@
 {
 "name": "ds-raw-03",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "global",
 "status": "passed",
+"meta": {
+"type": "node"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-complex-err/job-complex-err.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-complex-err/job-complex-err.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-complex-err",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "Container e2e is terminated state (exit code 0) due to reason: Completed: ",

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-default-01",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-default-02",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-errors/job-errors.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-errors/job-errors.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-errors",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "testerr",

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-01/job-junit-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-01/job-junit-01.golden.json
@@ -1,12 +1,16 @@
 {
 "name": "job-junit-01",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-02/job-junit-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-02/job-junit-02.golden.json
@@ -1,12 +1,16 @@
 {
 "name": "job-junit-02",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {
@@ -41,7 +45,8 @@
 "name": "output2.xml",
 "status": "failed",
 "meta": {
-"file": "results/global/output2.xml"
+"file": "results/global/output2.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-03/job-junit-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-03/job-junit-03.golden.json
@@ -1,12 +1,16 @@
 {
 "name": "job-junit-03",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "passed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {
@@ -41,7 +45,8 @@
 "name": "output2.xml",
 "status": "failed",
 "meta": {
-"file": "results/global/output2.xml"
+"file": "results/global/output2.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/job-junit-falsepositive.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-falsepositive/job-junit-falsepositive.golden.json
@@ -1,12 +1,16 @@
 {
 "name": "job-junit-falsepositive",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",
 "status": "failed",
 "meta": {
-"file": "results/global/output.xml"
+"file": "results/global/output.xml",
+"type": "file"
 },
 "items": [
 {

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-01/job-raw-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-01/job-raw-01.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-raw-01",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-02/job-raw-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-02/job-raw-02.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-raw-02",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-03/job-raw-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-03/job-raw-03.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-raw-03",
 "status": "passed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "output.xml",

--- a/pkg/client/results/testdata/mockResults/plugins/job-timeout/job-timeout.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-timeout/job-timeout.golden.json
@@ -1,6 +1,9 @@
 {
 "name": "job-timeout",
 "status": "failed",
+"meta": {
+"type": "summary"
+},
 "items": [
 {
 "name": "timeout waiting for results",


### PR DESCRIPTION
**What this PR does / why we need it**:
If you look at the sonobuoy_results.yaml it can be a bit confusing
understanding the tree structure and what each node in that tree means.

This adds some extra metadata to certain Items (plugin summary, nodes,
and files) in order to make the raw file more comprehensible and
potentially aid in other processing.

**Which issue(s) this PR fixes**
Fixes #1047

**Release note**:
```
Adds additional metadata into the sonobuoy_results.yaml file to help indicate what each node in the tree represents.
```
