### PR TITLE
Adds commands to print default plugin definitions

### DIFF
--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -67,7 +67,10 @@ type genFlags struct {
 	genflags *pflag.FlagSet
 }
 
+// TODO(jschnake): Avoid using these globals if possible.
 var genflags genFlags
+var genSystemdLogsflags genFlags
+var genE2Eflags genFlags
 
 func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	genset := pflag.NewFlagSet("generate", pflag.ExitOnError)

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -40,9 +40,13 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdE2E())
 
 	gen := NewCmdGen()
-	gen.AddCommand(NewCmdGenPluginDef())
+	genPlugin := NewCmdGenPluginDef()
+	genPlugin.AddCommand(NewCmdGenE2E())
+	genPlugin.AddCommand(NewCmdGenSystemdLogs())
+	gen.AddCommand(genPlugin)
 	gen.AddCommand(NewCmdGenConfig())
 	gen.AddCommand(NewCmdGenImageRepoConfig())
+
 	cmds.AddCommand(gen)
 
 	cmds.AddCommand(NewCmdLogs())

--- a/pkg/plugin/manifest/helper/helper.go
+++ b/pkg/plugin/manifest/helper/helper.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/driver"
+	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
+
+	"github.com/pkg/errors"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// ToYAML will serialize the manifest and add the default podspec (based on the appropriate drive)
+// if not already set in the manifest.
+func ToYAML(m *manifest.Manifest, showDefaultPodSpec bool) ([]byte, error) {
+	if showDefaultPodSpec && m.PodSpec == nil {
+		m.PodSpec = &manifest.PodSpec{
+			PodSpec: driver.DefaultPodSpec(m.SonobuoyConfig.Driver),
+		}
+	}
+	yaml, err := kuberuntime.Encode(manifest.Encoder, m)
+	return yaml, errors.Wrapf(err, "serializing plugin %v as YAML", m.SonobuoyConfig.PluginName)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We have the `sonobuoy gen` command which prints a lot of
different types of resources and `sonobuoy gen plugin` which
prints custom plugin definitions. Sometimes it would be helpful
to be able to print the default e2e or sytemdlogs plugin definitions
so that they can be tweaked.

Added two commands `sonobuoy gen plugins e2e` and
`sonobuoy gen plugins systemd-logs` which does this.

Minor tweak to code organization to improve code reuse.

**Which issue(s) this PR fixes**
Fixes #991

**Special notes for your reviewer**:
These were just printing some data by hitting a code path that was already being used/tested. I didn't add any new tests for this code. Let me know if you want to add some basic one.

**Release note**:
```
Adds two subcommands (e2e and systemd-logs) to `sonobuoy gen plugin` which will print those plugin definitions respectively. This will hopefully make certain workflows easier by giving users a starting point for their plugin definition.
```
