### PR TITLE
Improve error message from GetStatus

### DIFF
--- a/pkg/plugin/aggregation/status.go
+++ b/pkg/plugin/aggregation/status.go
@@ -108,7 +108,7 @@ func (s *Status) updateStatus() error {
 // is returned.
 func GetStatus(client kubernetes.Interface, namespace string) (*Status, error) {
 	if _, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{}); err != nil {
-		return nil, errors.Wrap(err, "sonobuoy namespace does not exist")
+		return nil, errors.Wrapf(err, "failed to get namespace %v", namespace)
 	}
 
 	// Determine sonobuoy pod name


### PR DESCRIPTION
**What this PR does / why we need it**:
The GetStatus function assumed that any error when getting a namespace
was due to that namespace not existing. Instead state that it was an
error when getting the namespace.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1055 