### PR TITLE
Refactor image client to not be E2E specific

### DIFF
--- a/pkg/image/images_test.go
+++ b/pkg/image/images_test.go
@@ -19,17 +19,11 @@ package image
 import (
 	"testing"
 
-	"github.com/vmware-tanzu/sonobuoy/pkg/image/docker"
 	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/sonobuoy/pkg/image/docker"
 )
 
-var imgs = map[string]Config{
-	"test": Config{
-		name:     "test1",
-		registry: "foo.io/sonobuoy",
-		version:  "x.y",
-	},
-}
+var imgs = []string{"test1/foo.io/sonobuoy:x.y"}
 
 type FakeDockerClient struct {
 	imageExists bool
@@ -83,17 +77,11 @@ func (l FakeDockerClient) Save(images []string, filename string) error {
 }
 
 func TestPushImages(t *testing.T) {
-	var privateImgs = map[string]Config{
-		"test": Config{
-			name:     "test1",
-			registry: "private.io/sonobuoy",
-			version:  "x.y",
-		},
-	}
+	var privateImgs = []string{"test1/private.io/sonobuoy:x.y"}
 
 	tests := map[string]struct {
 		client         docker.Docker
-		privateImgs    map[string]Config
+		privateImgs    []string
 		wantErrorCount int
 	}{
 		"simple": {

--- a/pkg/image/manifest_test.go
+++ b/pkg/image/manifest_test.go
@@ -76,3 +76,49 @@ func TestGetDefaultImageRegistryVersionValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestFullQualifiedImageName(t *testing.T) {
+	img := Config{
+		registry: "docker.io/sonobuoy",
+		name:     "testimage",
+		tag:      "latest",
+	}
+	expected := "docker.io/sonobuoy/testimage:latest"
+	actual := img.GetFullyQualifiedImageName()
+	if actual != expected {
+		t.Errorf("expected image name to be %q, got %q", expected, actual)
+	}
+}
+
+func TestGetImageNames(t *testing.T) {
+	registry, err := NewRegistryList("", "v1.17.0")
+	if err != nil {
+		t.Fatalf("unexpected error from NewRegistryList %q", err)
+	}
+
+	imageNames, err := registry.GetImageNames()
+	if err != nil {
+		t.Fatalf("unexpected error from GetImageNames %q", err)
+	}
+
+	expectedRegistry := registry.v1_17()
+	if len(imageNames) != len(expectedRegistry) {
+		t.Fatalf("Unexpected number of images returned, expected %v, got %v", len(expectedRegistry), len(imageNames))
+	}
+
+	// Check one of the returned image names to ensure correct format
+	registryImage := expectedRegistry["Agnhost"]
+	registryImageName := registryImage.GetFullyQualifiedImageName()
+	if !contains(imageNames, registryImageName) {
+		t.Errorf("Expected result of GetImageNames to contain registry image %q", registryImageName)
+	}
+}
+
+func contains(set []string, val string) bool {
+	for _, v := range set {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing client for handling plugin images assumed that the images
were for the e2e plugin. We are trying to add support for other images
so we need to make the image client more generic. This change refactors
the image client to deal with image names rather than the internal
Kubernetes image `Config` type.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Part of #1028 

**Special notes for your reviewer**:
Creating this as a Draft PR for now to check coverage/tests
