### PR TITLE
Add support for pulling and pushing all images

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -40,6 +40,7 @@ const (
 	pluginFlag          = "plugin"
 	timeoutFlag         = "timeout"
 	waitOutputFlag      = "wait-output"
+	customRegistryFlag  = "custom-registry"
 	kubeconfig          = "kubeconfig"
 	context             = "context"
 )
@@ -124,17 +125,19 @@ func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	flags.StringVar(&cfg.Context, "context", "", "Context in the kubeconfig to use.")
 }
 
-// AddPluginFlag describes which plugin's images to interact with
-func AddPluginFlag(cfg *string, flags *pflag.FlagSet) {
-	// The default is 'e2e' since it's the only plugin enabled at the moment
-	flags.StringVarP(cfg, pluginFlag, "p", "e2e", "Describe which plugin's images to interact (Valid plugins are 'e2e').")
-}
-
 // AddE2ERegistryConfigFlag adds a e2eRegistryConfigFlag flag to the provided command.
 func AddE2ERegistryConfigFlag(cfg *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		cfg, e2eRegistryConfigFlag, "",
-		"Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.",
+		"Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images. Required when pushing images for the e2e plugin.",
+	)
+}
+
+// AddCustomRepoFlag adds a custom registry flag to the provided command.
+func AddCustomRegistryFlag(cfg *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		cfg, customRegistryFlag, "",
+		"Specify a registry to override the Sonobuoy and Plugin image registries.",
 	)
 }
 
@@ -350,11 +353,24 @@ func AddPluginEnvFlag(p *PluginEnvVars, flags *pflag.FlagSet) {
 	flags.Var(p, "plugin-env", "Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value")
 }
 
+// AddPluginListFlag adds the flag to keep track of which built-in plugins to use.
+func AddPluginListFlag(p *[]string, flags *pflag.FlagSet) {
+	flags.StringSliceVarP(p, "plugin", "p", []string{"e2e", "systemd-logs"}, "Describe which plugin's images to interact with (Valid plugins are 'e2e', 'systemd-logs').")
+}
+
 // AddShortFlag adds a boolean flag to just print the Sonobuoy version and
 // nothing else. Useful in scripts.
 func AddShortFlag(flag *bool, flags *pflag.FlagSet) {
 	flags.BoolVar(
 		flag, "short", false,
 		"If true, prints just the sonobuoy version",
+	)
+}
+
+// AddDryRunFlag adds a boolean flag to perform a dry-run of image operations.
+func AddDryRunFlag(flag *bool, flags *pflag.FlagSet) {
+	flags.BoolVar(
+		flag, "dry-run", false,
+		"If true, only print the image operations that would be performed.",
 	)
 }

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -145,9 +145,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 			return nil, err
 		}
 
-		image = fmt.Sprintf("%v:%v",
-			resolveConformanceImage(imageVersion),
-			imageVersion)
+		image = resolveConformanceImage(imageVersion)
 	}
 
 	return &client.GenConfig{
@@ -175,14 +173,17 @@ func resolveConformanceImage(imageVersion string) string {
 	// required as we phase in the use of the upstream k8s kube-conformance
 	// image instead of our own heptio/kube-conformance one. They started
 	// publishing it for v1.14.1. (https://github.com/kubernetes/kubernetes/pull/76101)
+	var imageURL string
 	switch {
 	case imageVersion == imagepkg.ConformanceImageVersionLatest:
-		return config.UpstreamKubeConformanceImageURL
+		imageURL = config.UpstreamKubeConformanceImageURL
 	case imageVersion < "v1.14.1":
-		return config.DefaultKubeConformanceImageURL
+		imageURL = config.DefaultKubeConformanceImageURL
 	default:
-		return config.UpstreamKubeConformanceImageURL
+		imageURL = config.UpstreamKubeConformanceImageURL
 	}
+	return fmt.Sprintf("%v:%v", imageURL, imageVersion)
+
 }
 
 func NewCmdGen() *cobra.Command {

--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -46,35 +46,35 @@ func TestResolveConformanceImage(t *testing.T) {
 		{
 			name:             "Comparison is lexical",
 			requestedVersion: "foo",
-			expected:         "gcr.io/heptio-images/kube-conformance",
+			expected:         "gcr.io/heptio-images/kube-conformance:foo",
 		}, {
 			name:             "Prior to v1.14.0 uses heptio and major.minor",
 			requestedVersion: "v1.13.99",
-			expected:         "gcr.io/heptio-images/kube-conformance",
+			expected:         "gcr.io/heptio-images/kube-conformance:v1.13.99",
 		}, {
 			name:             "v1.14.0 uses heptio and major.minor",
 			requestedVersion: "v1.14.0",
-			expected:         "gcr.io/heptio-images/kube-conformance",
+			expected:         "gcr.io/heptio-images/kube-conformance:v1.14.0",
 		}, {
 			name:             "v1.14.1 and after uses upstream and major.minor.patch",
 			requestedVersion: "v1.14.1",
-			expected:         "gcr.io/google-containers/conformance",
+			expected:         "gcr.io/google-containers/conformance:v1.14.1",
 		}, {
 			name:             "v1.14.0 and after uses upstream and major.minor.patch",
 			requestedVersion: "v1.15.1",
-			expected:         "gcr.io/google-containers/conformance",
+			expected:         "gcr.io/google-containers/conformance:v1.15.1",
 		}, {
 			name:             "latest should use upstream image",
 			requestedVersion: "latest",
-			expected:         "gcr.io/google-containers/conformance",
+			expected:         "gcr.io/google-containers/conformance:latest",
 		}, {
 			name:             "explicit version before v1.14.0 should use heptio image and given version",
 			requestedVersion: "v1.12+.0.alpha+",
-			expected:         "gcr.io/heptio-images/kube-conformance",
+			expected:         "gcr.io/heptio-images/kube-conformance:v1.12+.0.alpha+",
 		}, {
 			name:             "explicit version after v1.14.0 should use upstream and use given version",
 			requestedVersion: "v1.14.1",
-			expected:         "gcr.io/google-containers/conformance",
+			expected:         "gcr.io/google-containers/conformance:v1.14.1",
 		},
 	}
 

--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -19,7 +19,9 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 	"github.com/vmware-tanzu/sonobuoy/pkg/image"
 
@@ -31,12 +33,16 @@ import (
 const (
 	numDockerRetries     = 1
 	defaultE2ERegistries = ""
+	e2ePlugin            = "e2e"
+	systemdLogsPlugin    = "systemd-logs"
 )
 
 type imagesFlags struct {
 	e2eRegistryConfig string
-	plugin            string
+	plugins           []string
 	kubeconfig        Kubeconfig
+	customRegistry    string
+	dryRun            bool
 }
 
 func NewCmdImages() *cobra.Command {
@@ -46,7 +52,7 @@ func NewCmdImages() *cobra.Command {
 		Use:   "images",
 		Short: "Manage images used in a plugin. Supported plugins are: 'e2e'",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := listImages(flags.plugin, flags.kubeconfig); err != nil {
+			if err := listImages(flags.plugins, flags.kubeconfig); err != nil {
 				errlog.LogError(err)
 				os.Exit(1)
 			}
@@ -55,7 +61,7 @@ func NewCmdImages() *cobra.Command {
 	}
 
 	AddKubeconfigFlag(&flags.kubeconfig, cmd.Flags())
-	AddPluginFlag(&flags.plugin, cmd.Flags())
+	AddPluginListFlag(&flags.plugins, cmd.Flags())
 
 	cmd.AddCommand(pullCmd())
 	cmd.AddCommand(pushCmd())
@@ -67,11 +73,19 @@ func NewCmdImages() *cobra.Command {
 
 func pullCmd() *cobra.Command {
 	var flags imagesFlags
+
 	pullCmd := &cobra.Command{
 		Use:   "pull",
 		Short: "Pulls images to local docker client for a specific plugin",
 		Run: func(cmd *cobra.Command, args []string) {
-			if errs := pullImages(flags.plugin, flags.kubeconfig, flags.e2eRegistryConfig); len(errs) > 0 {
+			var client image.Client
+			if flags.dryRun {
+				client = image.DryRunClient{}
+			} else {
+				client = image.NewDockerClient()
+			}
+
+			if errs := pullImages(flags.plugins, flags.kubeconfig, flags.e2eRegistryConfig, client); len(errs) > 0 {
 				for _, err := range errs {
 					errlog.LogError(err)
 				}
@@ -82,7 +96,8 @@ func pullCmd() *cobra.Command {
 	}
 	AddE2ERegistryConfigFlag(&flags.e2eRegistryConfig, pullCmd.Flags())
 	AddKubeconfigFlag(&flags.kubeconfig, pullCmd.Flags())
-	AddPluginFlag(&flags.plugin, pullCmd.Flags())
+	AddPluginListFlag(&flags.plugins, pullCmd.Flags())
+	AddDryRunFlag(&flags.dryRun, pullCmd.Flags())
 
 	return pullCmd
 }
@@ -92,8 +107,21 @@ func pushCmd() *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:   "push",
 		Short: "Pushes images to docker registry for a specific plugin",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if contains(flags.plugins, e2ePlugin) && len(flags.e2eRegistryConfig) == 0 {
+				return fmt.Errorf("Required flag %q not set", e2eRegistryConfigFlag)
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if errs := pushImages(flags.plugin, flags.kubeconfig, flags.e2eRegistryConfig); len(errs) > 0 {
+			var client image.Client
+			if flags.dryRun {
+				client = image.DryRunClient{}
+			} else {
+				client = image.NewDockerClient()
+			}
+
+			if errs := pushImages(flags.plugins, flags.kubeconfig, flags.customRegistry, flags.e2eRegistryConfig, client); len(errs) > 0 {
 				for _, err := range errs {
 					errlog.LogError(err)
 				}
@@ -104,9 +132,10 @@ func pushCmd() *cobra.Command {
 	}
 	AddE2ERegistryConfigFlag(&flags.e2eRegistryConfig, pushCmd.Flags())
 	AddKubeconfigFlag(&flags.kubeconfig, pushCmd.Flags())
-	AddPluginFlag(&flags.plugin, pushCmd.Flags())
-	// TODO(bridget): This won't be required when dealing with other plugins
-	pushCmd.MarkFlagRequired(e2eRegistryConfigFlag)
+	AddPluginListFlag(&flags.plugins, pushCmd.Flags())
+	AddCustomRegistryFlag(&flags.customRegistry, pushCmd.Flags())
+	AddDryRunFlag(&flags.dryRun, pushCmd.Flags())
+	pushCmd.MarkFlagRequired(customRegistryFlag)
 
 	return pushCmd
 }
@@ -117,7 +146,14 @@ func downloadCmd() *cobra.Command {
 		Use:   "download",
 		Short: "Saves downloaded images from local docker client to a tar file",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := downloadImages(flags.plugin, flags.kubeconfig, flags.e2eRegistryConfig); err != nil {
+			var client image.Client
+			if flags.dryRun {
+				client = image.DryRunClient{}
+			} else {
+				client = image.NewDockerClient()
+			}
+
+			if err := downloadImages(flags.plugins, flags.kubeconfig, flags.e2eRegistryConfig, client); err != nil {
 				errlog.LogError(err)
 				os.Exit(1)
 			}
@@ -126,7 +162,8 @@ func downloadCmd() *cobra.Command {
 	}
 	AddE2ERegistryConfigFlag(&flags.e2eRegistryConfig, downloadCmd.Flags())
 	AddKubeconfigFlag(&flags.kubeconfig, downloadCmd.Flags())
-	AddPluginFlag(&flags.plugin, downloadCmd.Flags())
+	AddPluginListFlag(&flags.plugins, downloadCmd.Flags())
+	AddDryRunFlag(&flags.dryRun, downloadCmd.Flags())
 	return downloadCmd
 }
 
@@ -136,7 +173,14 @@ func deleteCmd() *cobra.Command {
 		Use:   "delete",
 		Short: "Deletes all images downloaded to local docker client",
 		Run: func(cmd *cobra.Command, args []string) {
-			if errs := deleteImages(flags.plugin, flags.kubeconfig, flags.e2eRegistryConfig); len(errs) > 0 {
+			var client image.Client
+			if flags.dryRun {
+				client = image.DryRunClient{}
+			} else {
+				client = image.NewDockerClient()
+			}
+
+			if errs := deleteImages(flags.plugins, flags.kubeconfig, flags.e2eRegistryConfig, client); len(errs) > 0 {
 				for _, err := range errs {
 					errlog.LogError(err)
 				}
@@ -147,7 +191,8 @@ func deleteCmd() *cobra.Command {
 	}
 	AddE2ERegistryConfigFlag(&flags.e2eRegistryConfig, deleteCmd.Flags())
 	AddKubeconfigFlag(&flags.kubeconfig, deleteCmd.Flags())
-	AddPluginFlag(&flags.plugin, deleteCmd.Flags())
+	AddPluginListFlag(&flags.plugins, deleteCmd.Flags())
+	AddDryRunFlag(&flags.dryRun, deleteCmd.Flags())
 	return deleteCmd
 }
 
@@ -165,124 +210,176 @@ func getClusterVersion(kubeconfig Kubeconfig) (string, error) {
 	return version, nil
 }
 
-func listImages(plugin string, kubeconfig Kubeconfig) error {
-	switch plugin {
-	case "e2e":
-		version, err := getClusterVersion(kubeconfig)
-		if err != nil {
-			return errors.Wrap(err, "failed to get cluster version")
-		}
+func listImages(plugins []string, kubeconfig Kubeconfig) error {
+	images := []string{
+		config.DefaultImage,
+	}
+	for _, plugin := range plugins {
+		switch plugin {
+		case systemdLogsPlugin:
+			images = append(images, config.DefaultSystemdLogsImage)
+		case e2ePlugin:
+			version, err := getClusterVersion(kubeconfig)
+			if err != nil {
+				return errors.Wrap(err, "failed to get cluster version")
+			}
 
-		defaultImages, err := image.GetE2EImages(defaultE2ERegistries, version)
-		if err != nil {
-			return errors.Wrap(err, "couldn't get images")
-		}
+			e2eImages, err := image.GetE2EImages(defaultE2ERegistries, version)
+			if err != nil {
+				return errors.Wrap(err, "couldn't get images")
+			}
 
-		for _, image := range defaultImages {
-			fmt.Println(image)
+			images = append(images, resolveConformanceImage(version))
+			images = append(images, e2eImages...)
+		default:
+			return errors.Errorf("Unsupported plugin: %v", plugin)
 		}
-	default:
-		return errors.Errorf("Unsupported plugin: %v", plugin)
+	}
+
+	for _, image := range images {
+		fmt.Println(image)
 	}
 
 	return nil
 }
 
-func pullImages(plugin string, kubeconfig Kubeconfig, e2eRegistryConfig string) []error {
-	switch plugin {
-	case "e2e":
-		version, err := getClusterVersion(kubeconfig)
-		if err != nil {
-			return []error{errors.Wrap(err, "failed to get cluster version")}
+func pullImages(plugins []string, kubeconfig Kubeconfig, e2eRegistryConfig string, client image.Client) []error {
+	images := []string{
+		config.DefaultImage,
+	}
+	for _, plugin := range plugins {
+		switch plugin {
+		case systemdLogsPlugin:
+			images = append(images, config.DefaultSystemdLogsImage)
+		case e2ePlugin:
+			version, err := getClusterVersion(kubeconfig)
+			if err != nil {
+				return []error{errors.Wrap(err, "failed to get cluster version")}
+			}
+
+			e2eImages, err := image.GetE2EImages(e2eRegistryConfig, version)
+			if err != nil {
+				return []error{errors.Wrap(err, "couldn't get images")}
+			}
+			images = append(images, resolveConformanceImage(version))
+			images = append(images, e2eImages...)
+
+		default:
+			return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
 		}
-
-		images, err := image.GetE2EImages(e2eRegistryConfig, version)
-		if err != nil {
-			return []error{errors.Wrap(err, "couldn't get images")}
-		}
-
-		imageClient := image.NewImageClient()
-
-		return imageClient.PullImages(images, numDockerRetries)
-	default:
-		return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
 	}
 
+	return client.PullImages(images, numDockerRetries)
 }
 
-func downloadImages(plugin string, kubeconfig Kubeconfig, e2eRegistryConfig string) error {
-	switch plugin {
-	case "e2e":
-		version, err := getClusterVersion(kubeconfig)
-		if err != nil {
-			return errors.Wrap(err, "failed to get cluster version")
+func downloadImages(plugins []string, kubeconfig Kubeconfig, e2eRegistryConfig string, client image.Client) error {
+	for _, plugin := range plugins {
+		switch plugin {
+		case e2ePlugin:
+			version, err := getClusterVersion(kubeconfig)
+			if err != nil {
+				return errors.Wrap(err, "failed to get cluster version")
+			}
+
+			images, err := image.GetE2EImages(e2eRegistryConfig, version)
+			if err != nil {
+				return errors.Wrap(err, "couldn't get images")
+			}
+
+			fileName, err := client.DownloadImages(images, version)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(fileName)
+
+		default:
+			return errors.Errorf("Unsupported plugin: %v", plugin)
 		}
-
-		images, err := image.GetE2EImages(e2eRegistryConfig, version)
-		if err != nil {
-			return errors.Wrap(err, "couldn't get images")
-		}
-
-		imageClient := image.NewImageClient()
-
-		fileName, err := imageClient.DownloadImages(images, version)
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(fileName)
-
-	default:
-		return errors.Errorf("Unsupported plugin: %v", plugin)
 	}
 
 	return nil
 }
 
-func pushImages(plugin string, kubeconfig Kubeconfig, e2eRegistryConfig string) []error {
-	switch plugin {
-	case "e2e":
-		version, err := getClusterVersion(kubeconfig)
-		if err != nil {
-			return []error{errors.Wrap(err, "failed to get cluster version")}
-		}
-
-		defaultImages, err := image.GetE2EImages(defaultE2ERegistries, version)
-		if err != nil {
-			return []error{errors.Wrap(err, "couldn't get images")}
-		}
-
-		privateImages, err := image.GetE2EImages(e2eRegistryConfig, version)
-		if err != nil {
-			return []error{errors.Wrap(err, "couldn't get images")}
-		}
-
-		imageClient := image.NewImageClient()
-
-		return imageClient.PushImages(defaultImages, privateImages, numDockerRetries)
-	default:
-		return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
+func pushImages(plugins []string, kubeconfig Kubeconfig, customRegistry, e2eRegistryConfig string, client image.Client) []error {
+	imagePairs := []image.TagPair{
+		{
+			Src: config.DefaultImage,
+			Dst: substituteRegistry(config.DefaultImage, customRegistry),
+		},
 	}
+	for _, plugin := range plugins {
+		switch plugin {
+		case systemdLogsPlugin:
+			imagePairs = append(imagePairs, image.TagPair{
+				Src: config.DefaultSystemdLogsImage,
+				Dst: substituteRegistry(config.DefaultSystemdLogsImage, customRegistry),
+			})
+		case e2ePlugin:
+			version, err := getClusterVersion(kubeconfig)
+			if err != nil {
+				return []error{errors.Wrap(err, "failed to get cluster version")}
+			}
+
+			tagPairs, err := image.GetE2EImageTagPairs(e2eRegistryConfig, version)
+			if err != nil {
+				return []error{errors.Wrap(err, "couldn't...something")}
+			}
+
+			conformanceImage := resolveConformanceImage(version)
+			imagePairs = append(imagePairs, image.TagPair{
+				Src: conformanceImage,
+				Dst: substituteRegistry(conformanceImage, customRegistry),
+			})
+			imagePairs = append(imagePairs, tagPairs...)
+		default:
+			return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
+		}
+	}
+
+	return client.PushImages(imagePairs, numDockerRetries)
 }
 
-func deleteImages(plugin string, kubeconfig Kubeconfig, e2eRegistryConfig string) []error {
-	switch plugin {
-	case "e2e":
-		version, err := getClusterVersion(kubeconfig)
-		if err != nil {
-			return []error{errors.Wrap(err, "failed to get cluster version")}
-		}
-
-		images, err := image.GetE2EImages(e2eRegistryConfig, version)
-		if err != nil {
-			return []error{errors.Wrap(err, "couldn't get images")}
-		}
-
-		imageClient := image.NewImageClient()
-
-		return imageClient.DeleteImages(images, numDockerRetries)
-
-	default:
-		return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
+func deleteImages(plugins []string, kubeconfig Kubeconfig, e2eRegistryConfig string, client image.Client) []error {
+	images := []string{
+		config.DefaultImage,
 	}
+	for _, plugin := range plugins {
+		switch plugin {
+		case systemdLogsPlugin:
+			images = append(images, config.DefaultSystemdLogsImage)
+		case e2ePlugin:
+			version, err := getClusterVersion(kubeconfig)
+			if err != nil {
+				return []error{errors.Wrap(err, "failed to get cluster version")}
+			}
+
+			e2eImages, err := image.GetE2EImages(e2eRegistryConfig, version)
+			if err != nil {
+				return []error{errors.Wrap(err, "couldn't get images")}
+			}
+
+			images = append(images, resolveConformanceImage(version))
+			images = append(images, e2eImages...)
+		default:
+			return []error{errors.Errorf("Unsupported plugin: %v", plugin)}
+		}
+	}
+
+	return client.DeleteImages(images, numDockerRetries)
+}
+
+func substituteRegistry(image string, customRegistry string) string {
+	trimmedRegistry := strings.TrimRight(customRegistry, "/")
+	components := strings.SplitAfter(image, "/")
+	return fmt.Sprintf("%s/%s", trimmedRegistry, components[len(components)-1])
+}
+
+func contains(set []string, val string) bool {
+	for _, v := range set {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/sonobuoy/app/images_test.go
+++ b/cmd/sonobuoy/app/images_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+
+	 Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+)
+
+func TestSubstituteRegistry(t *testing.T) {
+	testCases := []struct {
+		name           string
+		image          string
+		customRegistry string
+		expected       string
+	}{
+		{
+			name:           "Image with no registry has custom registry prepended",
+			image:          "sonobuoy:v0.17.0",
+			customRegistry: "my-custom-repo",
+			expected:       "my-custom-repo/sonobuoy:v0.17.0",
+		},
+		{
+			name:           "Registry is replaced with custom registry",
+			image:          "sonobuoy/sonobuoy:v0.17.0",
+			customRegistry: "my-custom-repo",
+			expected:       "my-custom-repo/sonobuoy:v0.17.0",
+		},
+		{
+			name:           "Custom registry ending with / does not result in // in result",
+			image:          "sonobuoy/sonobuoy:v0.17.0",
+			customRegistry: "my-custom-repo/",
+			expected:       "my-custom-repo/sonobuoy:v0.17.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := substituteRegistry(tc.image, tc.customRegistry)
+			if tc.expected != actual {
+				t.Errorf("Unexpected registry substition, expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+
+}

--- a/pkg/image/docker_client.go
+++ b/pkg/image/docker_client.go
@@ -1,0 +1,115 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/sonobuoy/pkg/image/docker"
+)
+
+// DockerClient is an implementation of Client that uses the local docker installation
+// to interact with images.
+type DockerClient struct {
+	dockerClient docker.Docker
+}
+
+// TagPair represents a source image and a destination image that it will be tagged and
+// pushed as.
+type TagPair struct {
+	Src string
+	Dst string
+}
+
+// NewDockerClient returns a DockerClient that can interact with the local docker installation.
+func NewDockerClient() Client {
+	return DockerClient{
+		dockerClient: docker.LocalDocker{},
+	}
+}
+
+// PullImages pulls the given list of images, skipping if they are already present on the machine.
+// It will retry for the provided number of retries on failure.
+func (i DockerClient) PullImages(images []string, retries int) []error {
+	errs := []error{}
+	for _, image := range images {
+		err := i.dockerClient.PullIfNotPresent(image, retries)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "couldn't pull image: %v", image))
+		}
+	}
+	return errs
+}
+
+// PushImages will tag each of the source images as the destination image and push.
+// It will skip the operation if the image source and destination are equal.
+// It will retry for the provided number of retries on failure.
+func (i DockerClient) PushImages(images []TagPair, retries int) []error {
+	errs := []error{}
+	for _, image := range images {
+		// Skip if the source/dest are equal
+		if image.Src == image.Dst {
+			fmt.Printf("Skipping public image: %s\n", image.Src)
+			continue
+		}
+
+		err := i.dockerClient.Tag(image.Src, image.Dst, retries)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "couldn't tag image %q as %q", image.Src, image.Dst))
+		}
+
+		err = i.dockerClient.Push(image.Dst, retries)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "couldn't push image: %v", image.Dst))
+		}
+	}
+	return errs
+}
+
+// DownloadImages exports the list of images to a tar file. The provided version will be included in the
+// resulting file name.
+func (i DockerClient) DownloadImages(images []string, version string) (string, error) {
+	fileName := getTarFileName(version)
+
+	err := i.dockerClient.Save(images, fileName)
+	if err != nil {
+		return "", errors.Wrap(err, "couldn't save images to tar")
+	}
+
+	return fileName, nil
+}
+
+// DeleteImages deletes the given list of images from the local machine.
+// It will retry for the provided number of retries on failure.
+func (i DockerClient) DeleteImages(images []string, retries int) []error {
+	errs := []error{}
+
+	for _, image := range images {
+		err := i.dockerClient.Rmi(image, retries)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "couldn't delete image: %v", image))
+		}
+	}
+
+	return errs
+}
+
+// getTarFileName returns a filename matching the version of Kubernetes images are exported
+func getTarFileName(version string) string {
+	return fmt.Sprintf("kubernetes_e2e_images_%s.tar", version)
+}

--- a/pkg/image/docker_client_test.go
+++ b/pkg/image/docker_client_test.go
@@ -77,11 +77,22 @@ func (l FakeDockerClient) Save(images []string, filename string) error {
 }
 
 func TestPushImages(t *testing.T) {
-	var privateImgs = []string{"test1/private.io/sonobuoy:x.y"}
+	imageTagPairs := []TagPair{
+		{
+			Src: imgs[0],
+			Dst: "test1/private.io/sonobuoy:x.y",
+		},
+	}
+	imageTagPairSame := []TagPair{
+		{
+			Src: imgs[0],
+			Dst: imgs[0],
+		},
+	}
 
 	tests := map[string]struct {
 		client         docker.Docker
-		privateImgs    []string
+		imageTagPairs  []TagPair
 		wantErrorCount int
 	}{
 		"simple": {
@@ -89,7 +100,7 @@ func TestPushImages(t *testing.T) {
 				pushFails: false,
 				tagFails:  false,
 			},
-			privateImgs:    privateImgs,
+			imageTagPairs:  imageTagPairs,
 			wantErrorCount: 0,
 		},
 		"tag fails": {
@@ -97,7 +108,7 @@ func TestPushImages(t *testing.T) {
 				pushFails: false,
 				tagFails:  true,
 			},
-			privateImgs:    privateImgs,
+			imageTagPairs:  imageTagPairs,
 			wantErrorCount: 1,
 		},
 		"push fails": {
@@ -105,7 +116,7 @@ func TestPushImages(t *testing.T) {
 				pushFails: true,
 				tagFails:  true,
 			},
-			privateImgs:    privateImgs,
+			imageTagPairs:  imageTagPairs,
 			wantErrorCount: 2,
 		},
 		"source images equal destination images": {
@@ -113,7 +124,7 @@ func TestPushImages(t *testing.T) {
 				pushFails: true,
 				tagFails:  true,
 			},
-			privateImgs:    imgs,
+			imageTagPairs:  imageTagPairSame,
 			wantErrorCount: 0,
 		},
 	}
@@ -121,11 +132,11 @@ func TestPushImages(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			imgClient := ImageClient{
+			imgClient := DockerClient{
 				dockerClient: tc.client,
 			}
 
-			got := imgClient.PushImages(imgs, tc.privateImgs, 0)
+			got := imgClient.PushImages(tc.imageTagPairs, 0)
 
 			if len(got) != tc.wantErrorCount {
 				t.Fatalf("Expected errors: %d but got %d", tc.wantErrorCount, len(got))
@@ -166,7 +177,7 @@ func TestPullImages(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			imgClient := ImageClient{
+			imgClient := DockerClient{
 				dockerClient: tc.client,
 			}
 
@@ -206,7 +217,7 @@ func TestDownloadImages(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			imgClient := ImageClient{
+			imgClient := DockerClient{
 				dockerClient: tc.client,
 			}
 
@@ -244,7 +255,7 @@ func TestDeleteImages(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			imgClient := ImageClient{
+			imgClient := DockerClient{
 				dockerClient: tc.client,
 			}
 

--- a/pkg/image/dryrun_client.go
+++ b/pkg/image/dryrun_client.go
@@ -1,0 +1,56 @@
+/*
+Copyright the Sonobuoy contributors 2020
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// DryRunClient is an implementation of Client that logs the image operations that would
+// be performed rather than performing them.
+type DryRunClient struct{}
+
+// PullImages logs the images that would be pulled.
+func (i DryRunClient) PullImages(images []string, retries int) []error {
+	for _, image := range images {
+		logrus.Infof("Pulling image: %s", image)
+	}
+	return []error{}
+}
+
+// PushImages logs what the images would be tagged and pushed as.
+func (i DryRunClient) PushImages(images []TagPair, retries int) []error {
+	for _, image := range images {
+		logrus.Infof("Tagging image: %s as %s", image.Src, image.Dst)
+		logrus.Infof("Pushing image: %s", image.Dst)
+	}
+	return []error{}
+}
+
+// DownloadImages logs that the images would be saved and returns the tarball name.
+func (i DryRunClient) DownloadImages(images []string, version string) (string, error) {
+	logrus.Info("Saving images")
+	return getTarFileName(version), nil
+}
+
+// DeleteImages logs which images would be deleted.
+func (i DryRunClient) DeleteImages(images []string, retries int) []error {
+	for _, image := range images {
+		logrus.Infof("Deleting image: %s\n", image)
+	}
+	return []error{}
+}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,5 +1,5 @@
 /*
-Copyright the Sonobuoy contributors 2019
+Copyright the Sonobuoy contributors 2020
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,98 +16,10 @@ limitations under the License.
 
 package image
 
-import (
-	"fmt"
-
-	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/sonobuoy/pkg/image/docker"
-)
-
-type ImageClient struct {
-	dockerClient docker.Docker
-}
-
-func NewImageClient() ImageClient {
-	return ImageClient{
-		dockerClient: docker.LocalDocker{},
-	}
-}
-
-func (i ImageClient) PullImages(images []string, retries int) []error {
-	errs := []error{}
-	for _, image := range images {
-		err := i.dockerClient.PullIfNotPresent(image, retries)
-		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "couldn't pull image: %v", image))
-		}
-	}
-	return errs
-}
-
-func (i ImageClient) PushImages(upstreamImages, privateImages []string, retries int) []error {
-	errs := []error{}
-	for k, upstreamImg := range upstreamImages {
-		privateImg := privateImages[k]
-
-		// Skip if the source/dest are equal
-		if privateImg == upstreamImg {
-			fmt.Printf("Skipping public image: %s\n", upstreamImg)
-			continue
-		}
-
-		err := i.dockerClient.Tag(upstreamImg, privateImg, retries)
-		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "couldn't tag image %q as %q", upstreamImg, privateImg))
-		}
-
-		err = i.dockerClient.Push(privateImg, retries)
-		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "couldn't push image: %v", privateImg))
-		}
-	}
-	return errs
-}
-
-func (i ImageClient) DownloadImages(images []string, version string) (string, error) {
-	fileName := getTarFileName(version)
-
-	err := i.dockerClient.Save(images, fileName)
-	if err != nil {
-		return "", errors.Wrap(err, "couldn't save images to tar")
-	}
-
-	return fileName, nil
-}
-
-func (i ImageClient) DeleteImages(images []string, retries int) []error {
-	errs := []error{}
-
-	for _, image := range images {
-		err := i.dockerClient.Rmi(image, retries)
-		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "couldn't delete image: %v", image))
-		}
-	}
-
-	return errs
-}
-
-// GetE2EImages gets a list of E2E image names
-func GetE2EImages(e2eRegistryConfig, version string) ([]string, error) {
-	// Get list of upstream images that match the version
-	reg, err := NewRegistryList(e2eRegistryConfig, version)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't create image registry list")
-	}
-
-	imgs, err := reg.GetImageNames()
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't get images for version")
-	}
-	return imgs, nil
-}
-
-// getTarFileName returns a filename matching the version of Kubernetes images are exported
-func getTarFileName(version string) string {
-	return fmt.Sprintf("kubernetes_e2e_images_%s.tar", version)
+// Client is the interface for interacting with images.
+type Client interface {
+	PullImages(images []string, retries int) []error
+	PushImages(images []TagPair, retries int) []error
+	DownloadImages(images []string, version string) (string, error)
+	DeleteImages(images []string, retries int) []error
 }

--- a/pkg/image/manifest_test.go
+++ b/pkg/image/manifest_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package image
 
 import (
+	"io/ioutil"
 	"strings"
 	"testing"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestGetDefaultImageRegistryVersionValidation(t *testing.T) {
@@ -90,15 +93,16 @@ func TestFullQualifiedImageName(t *testing.T) {
 	}
 }
 
-func TestGetImageNames(t *testing.T) {
-	registry, err := NewRegistryList("", "v1.17.0")
+func TestGetE2EImages(t *testing.T) {
+	version := "v1.17.0"
+	registry, err := NewRegistryList("", version)
 	if err != nil {
-		t.Fatalf("unexpected error from NewRegistryList %q", err)
+		t.Fatalf("unexpected error from NewRegistryList: %q", err)
 	}
 
-	imageNames, err := registry.GetImageNames()
+	imageNames, err := GetE2EImages("", version)
 	if err != nil {
-		t.Fatalf("unexpected error from GetImageNames %q", err)
+		t.Fatalf("unexpected error from GetE2EImages: %q", err)
 	}
 
 	expectedRegistry := registry.v1_17()
@@ -111,6 +115,70 @@ func TestGetImageNames(t *testing.T) {
 	registryImageName := registryImage.GetFullyQualifiedImageName()
 	if !contains(imageNames, registryImageName) {
 		t.Errorf("Expected result of GetImageNames to contain registry image %q", registryImageName)
+	}
+}
+
+func createTestRegistryConfig(customRegistry string) (string, error) {
+	registries, err := GetDefaultImageRegistries("v1.15.0")
+	if err != nil {
+		return "", err
+	}
+
+	registries.E2eRegistry = customRegistry
+	registries.DockerLibraryRegistry = customRegistry
+	registries.GcRegistry = customRegistry
+	registries.SampleRegistry = customRegistry
+
+	tmpfile, err := ioutil.TempFile("", "config.*.yaml")
+	if err != nil {
+		return "", err
+	}
+	defer tmpfile.Close()
+
+	d, err := yaml.Marshal(&registries)
+	if err != nil {
+		return "", err
+	}
+	if _, err := tmpfile.Write(d); err != nil {
+		return "", err
+	}
+	return tmpfile.Name(), nil
+}
+
+func TestGetE2EImageTagPairs(t *testing.T) {
+	version := "v1.15.0"
+	customRegistry := "my-custom/registry"
+	customRegistries, err := createTestRegistryConfig(customRegistry)
+	if err != nil {
+		t.Fatalf("unexpected error creating temp registry config: %q", err)
+	}
+
+	imageTagPairs, err := GetE2EImageTagPairs(customRegistries, version)
+	if err != nil {
+		t.Fatalf("unexpected error from GetE2ETagPairs: %q", err)
+	}
+
+	defaultRegistry, err := NewRegistryList("", version)
+	if err != nil {
+		t.Fatalf("unexpected error from NewRegistryList: %q", err)
+	}
+	expectedDefaultRegistry := defaultRegistry.v1_15()
+	if len(imageTagPairs) != len(expectedDefaultRegistry) {
+		t.Fatalf("Unexpected number of image tag pairs returned, expected %v, got %v", len(expectedDefaultRegistry), len(imageTagPairs))
+	}
+
+	// Check one of the returned image pairs to ensure correct format
+	imageTagPair := imageTagPairs[0]
+	if strings.HasPrefix(imageTagPair.Src, customRegistry) {
+		t.Errorf("Src image should not have custom registry prefix: %q", imageTagPair.Src)
+	}
+
+	imageComponents := strings.SplitAfter(imageTagPair.Src, "/")
+	if !strings.HasPrefix(imageTagPair.Dst, customRegistry) {
+		t.Errorf("Expected Dst image to have prefix %q, got %q", customRegistry, imageTagPair.Dst)
+	}
+	if !strings.HasSuffix(imageTagPair.Dst, imageComponents[len(imageComponents)-1]) {
+		t.Errorf("Expected Dst image to have suffix %q, got %q", imageComponents[len(imageComponents)-1], imageTagPair.Dst)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes adds support for pulling the Sonobuoy worker image, the
systemd-logs image and the Kubernetes conformance image in addition to
the images required for the e2e plugin.

The individual images to pull cannot be configured. Only the default
version for the cluster will be pulled. The images can only be pushed to
one registry which is specified with the new flags `--custom-registry`.

This currently only works for the default built in plugins. A follow up
change will be made to apply the same approach to any image in a plugin
definition.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1028 
- Fixes #1059 

**Special notes for your reviewer**:
I've tested the new commands for this manually. I ran the following locally:
```
sonobuoy images pull -p systemd-logs
sonobuoy images push -p systemd-logs --custom-registry zubron
```
And you can see that the images were pushed to my public registry: https://hub.docker.com/u/zubron

**Release note**:
```
Sonobuoy can now pull all images for Sonobuoy and the built-in plugins and push them to a custom registry. The E2E test images are still configured as before, however all other images will be pushed to a custom registry specified using the flag `--custom-registry`. The image operations can also be previewed by using the `--dry-run` flag.
```
