### PR TITLE
Update goreleaser to remove deprecated field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,8 @@ builds:
     - goos: windows
       goarch: arm64
   ldflags: -s -w -X github.com/vmware-tanzu/sonobuoy/pkg/buildinfo.Version=v{{.Version}} -X github.com/vmware-tanzu/sonobuoy/pkg/buildinfo.GitSHA={{.FullCommit}}
-archive:
-  format: tar.gz
-  files:
-  - LICENSE
+archives:
+  - id: tar
+    format: tar.gz
+    files:
+    - LICENSE


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser/commit/8defb77b0eea3d775b016b32f8d5f91890e4e1a7#diff-6bc8131dff9242f298c3811fada0c174L180-L196 removed the archive field and it needs updated for the release.
