### PR TITLE
Fix flag name for systemd-logs image

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -104,9 +104,19 @@ func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
 // AddSystemdLogsImage initialises the systemd-logs-image flag.
 func AddSystemdLogsImage(image *string, flags *pflag.FlagSet) {
 	flags.StringVar(
+		image, "systemd-logs-image", config.DefaultSystemdLogsImage,
+		"Container image override for the systemd-logs plugin image.",
+	)
+
+	// The flag for overriding the systemd-logs image was mistakenly defined as
+	// systemd-logs-flag. This flag remains but is marked as hidden and deprecated
+	// to prevent breaking the behaviour for existing users.
+	flags.StringVar(
 		image, "systemd-logs-flag", config.DefaultSystemdLogsImage,
 		"Container image override for the systemd-logs plugin image.",
 	)
+	flags.MarkHidden("systemd-logs-flag")
+	flags.MarkDeprecated("systemd-logs-flag", "please use --systemd-logs-image instead")
 }
 
 // AddKubeConformanceImageVersion initialises an image version flag.


### PR DESCRIPTION
**What this PR does / why we need it**:
The flag was mistakenly named `systemd-logs-flag` when it should have
been `systemd-logs-image`. The existing flag has been left in place but
has been marked as hidden and deprecated. It will continue to work but
will not appear in the help/usage.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Release note**:
```
The flag for specifying the image for `systemd-logs` plugin has been renamed from `systemd-logs-flag` to `systemd-logs-image`. The previous flag, `systemd-logs-flag`, is now deprecated and will be removed in a future release.
```
