### PR TITLE
Use filepath instead of path when possible

### DIFF
--- a/cmd/sonobuoy/app/worker.go
+++ b/cmd/sonobuoy/app/worker.go
@@ -25,17 +25,18 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
 	"github.com/vmware-tanzu/sonobuoy/pkg/worker"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 // NewCmdWorker is the cobra command that acts as the entrypoint for Sonobuoy when running
@@ -163,7 +164,7 @@ func runGather(global bool) error {
 	}
 
 	go worker.RelayProgressUpdates(cfg.ProgressUpdatesPort, progressURL.String(), client)
-	err = worker.GatherResults(cfg.ResultsDir+"/done", resultURL.String(), client, sigHandler(plugin.GracefulShutdownPeriod*time.Second))
+	err = worker.GatherResults(filepath.Join(cfg.ResultsDir, "done"), resultURL.String(), client, sigHandler(plugin.GracefulShutdownPeriod*time.Second))
 
 	return errors.Wrap(err, "gathering results")
 }

--- a/pkg/client/retrieve.go
+++ b/pkg/client/retrieve.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	pluginaggregation "github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -142,7 +142,7 @@ func UntarAll(reader io.Reader, destFile, prefix string) (filenames []string, re
 		entrySeq++
 		mode := header.FileInfo().Mode()
 		outFileName := path.Join(destFile, header.Name[len(prefix):])
-		baseName := path.Dir(outFileName)
+		baseName := filepath.Dir(outFileName)
 		if err := os.MkdirAll(baseName, 0755); err != nil {
 			return filenames, err
 		}
@@ -160,7 +160,7 @@ func UntarAll(reader io.Reader, destFile, prefix string) (filenames []string, re
 				return filenames, err
 			}
 			if exists {
-				outFileName = filepath.Join(outFileName, path.Base(header.Name))
+				outFileName = filepath.Join(outFileName, filepath.Base(header.Name))
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There may be more of these situations lurking around, but as we
try to support Windows nodes we need to make sure that we are using
filepath unless we know we need forward slashes (like in URLs).

This changes a few calls to path.XYZ to filepath.XYZ and updates some
tests in the same way.

**Which issue(s) this PR fixes**
xref #732

**Special notes for your reviewer**:

**Release note**:
```
N/A
```
