### PR TITLE
Update to use latest systemd-logs image

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,7 +63,7 @@ const (
 	DefaultDNSNamespace = "kube-system"
 
 	// DefaultSystemdLogsImage is the URL for the docker image used by the systemd-logs plugin
-	DefaultSystemdLogsImage = "gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest"
+	DefaultSystemdLogsImage = "sonobuoy/systemd-logs:v0.3"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
The image is now published to the sonobuoy repo on dockerhub.

In addition, the plugin code is now at github.com/vmware-tanzu/sonobuoy-plugins

**Special notes for your reviewer**:
Image is already there; you can test this manually with `gen` but if you run it, remember that you have to specify the sonobuoy aggregator command manually since as of now it will be left blank, run the run_master script, and exit early w/o being able to download results.

**Release note**:
```
Updates the location for the systemd-logs image (now on DockerHub under the sonobuoy organization)
```
