### PR TITLE
Increase compatibility for  building of Windows images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 jobs:
   check_go_mod:
     docker:
@@ -30,6 +31,10 @@ jobs:
       enabled: true
     steps:
       - checkout
+      - run:
+          name: Load images into docker from workspace
+          command: |
+            docker load -i /home/circleci/project/sonobuoyImages.tar.gz
       - run: ./scripts/ci/publish.sh
 
   build_clients:
@@ -45,7 +50,6 @@ jobs:
           paths: 
             - build/linux/amd64/*
             - build/linux/arm64/*
-            - build/linux/windows/amd64/*
 
   build_containers:
     machine:
@@ -57,7 +61,7 @@ jobs:
       - run:
           name: "Build Sonobuoy container images"
           command: |
-            make containers
+            make linux_containers
       - run:
           name: Save as tar files to persist to next step
           command: |
@@ -119,10 +123,10 @@ workflows:
       - check_go_mod
       - check_readme_sync
       - build_clients
+      - unit_tests
       - build_containers:
           requires:
             - build_clients
-      - unit_tests
       - integration_tests:
           requires:
             - build_clients

--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -1,0 +1,20 @@
+# Copyright 2019 Sonobuoy contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+MAINTAINER John Schnake "jschnake@vmware.com"
+
+ADD BINARY /sonobuoy.exe
+WORKDIR /
+CMD /sonobuoy.exe master --no-exit -v 3 --logtostderr

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -393,3 +393,9 @@ func AddDryRunFlag(flag *bool, flags *pflag.FlagSet) {
 		"If true, only print the image operations that would be performed.",
 	)
 }
+
+// AddNodeSelectorFlag adds the flag for gen/run which keeps track of node selectors
+// to add to the aggregator. Allows running of the aggregator on Windows nodes.
+func AddNodeSelectorsFlag(p *NodeSelectors, flags *pflag.FlagSet) {
+	flags.Var(p, "aggregator-node-selector", "Node selectors to add to the aggregator. Values can be given multiple times and are in the form key:value")
+}

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -61,6 +61,10 @@ type genFlags struct {
 	// generated at the current time and so we can't manipulate those objects.
 	pluginEnvs PluginEnvVars
 
+	// nodeSelectors, if set, will be applied to the aggregator allowing it to be
+	// schedule on specific nodes.
+	nodeSelectors NodeSelectors
+
 	// These two fields are here since to properly squash settings down into nested
 	// configs we need to tell whether or not values are default values or the user
 	// provided them on the command line/config file.
@@ -96,6 +100,8 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 
 	AddPluginSetFlag(&cfg.plugins, genset)
 	AddPluginEnvFlag(&cfg.pluginEnvs, genset)
+
+	AddNodeSelectorsFlag(&cfg.nodeSelectors, genset)
 	cfg.genflags = genset
 	return genset
 }
@@ -161,6 +167,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		StaticPlugins:        g.plugins.StaticPlugins,
 		PluginEnvOverrides:   g.pluginEnvs,
 		ShowDefaultPodSpec:   g.showDefaultPodSpec,
+		NodeSelectors:        g.nodeSelectors,
 	}, nil
 }
 

--- a/cmd/sonobuoy/app/node_selector.go
+++ b/cmd/sonobuoy/app/node_selector.go
@@ -1,0 +1,55 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// NodeSelectors are k-v pairs that will be added to the aggregator.
+type NodeSelectors map[string]string
+
+func (i *NodeSelectors) String() string { return fmt.Sprint((map[string]string)(*i)) }
+func (i *NodeSelectors) Type() string   { return "nodeSelectors" }
+
+// Set parses the value from the CLI and places it into the internal map. Expected
+// form is key:value. If no `:` is found or it is the last character
+// ("x" or "x:") then the value will be set as the empty string.
+func (i *NodeSelectors) Set(str string) error {
+	parts := strings.SplitN(str, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected form key:value but got %v parts when splitting by ':'", len(parts))
+	}
+
+	if len(parts[1]) == 0 {
+		return errors.New("expected form key:value with a non-empty value, but got value of length 0")
+	}
+
+	k := parts[0]
+	mapI := (map[string]string)(*i)
+
+	if mapI == nil {
+		mapI = map[string]string{}
+	}
+
+	mapI[k] = parts[1]
+
+	*i = mapI
+	return nil
+}

--- a/cmd/sonobuoy/app/node_selector_test.go
+++ b/cmd/sonobuoy/app/node_selector_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright the Sonobuoy contributors 2020
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"github.com/kylelemons/godebug/pretty"
+	"testing"
+)
+
+func TestSetNodeSelector(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		expectErr string
+		ns        NodeSelectors
+		expect    NodeSelectors
+		input     string
+	}{
+		{
+			desc:      "Empty key and value should error",
+			expectErr: "expected form key:value but got 1 parts when splitting by ':'",
+		},
+		{
+			desc:      "Empty value should error",
+			input:     "key:",
+			expectErr: "expected form key:value with a non-empty value, but got value of length 0",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.ns.Set(tc.input)
+			switch {
+			case err != nil && len(tc.expectErr) == 0:
+				t.Fatalf("Expected nil error but got %q", err)
+			case err != nil && len(tc.expectErr) > 0:
+				if fmt.Sprint(err) != tc.expectErr {
+					t.Errorf("Expected error \n\t%q\nbut got\n\t%q", tc.expectErr, err)
+				}
+				return
+			case err == nil && len(tc.expectErr) > 0:
+				t.Fatalf("Expected error %q but got nil", tc.expectErr)
+			default:
+				// No error
+			}
+
+			if diff := pretty.Compare(tc.expect, tc.ns); diff != "" {
+				t.Fatalf("\n\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/vmware-tanzu/sonobuoy/pkg/client"
-	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/sonobuoy/pkg/client"
+	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/util/exec"
 )
@@ -91,7 +91,6 @@ func retrieveResults(cmd *cobra.Command, args []string) {
 	if _, ok := err.(exec.CodeExitError); ok {
 		fmt.Fprintln(os.Stderr, "Results not ready yet. Check `sonobuoy status` for status.")
 		os.Exit(1)
-
 	} else if err != nil {
 		fmt.Fprintf(os.Stderr, "error retrieving results: %v\n", err)
 		os.Exit(2)

--- a/examples/plugins/windows-plugin/Dockerfile
+++ b/examples/plugins/windows-plugin/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2019 Sonobuoy contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/windows/servercore:1809
+MAINTAINER John Schnake "jschnake@vmware.com"
+
+ADD run.ps1 /run.ps1
+WORKDIR /
+CMD powershell.exe ./run.ps1

--- a/examples/plugins/windows-plugin/README.md
+++ b/examples/plugins/windows-plugin/README.md
@@ -1,0 +1,42 @@
+# Example Windows Plugin
+
+This directory contains the code to build a Docker image which can be run as a Sonobuoy plugin on a Windows node.
+
+## Prerequisites
+
+To build the image you need to have a Windows machine (or VM) available. One example of how to set up a Windows VM and utilize it as your Docker context in [StefanScherer/windows-docker-machine](https://github.com/StefanScherer/windows-docker-machine).
+
+To run the plugin you need to have a Kubernetes cluster with Windows nodes. The Windows nodes should have the label `kubernetes.io/os=windows`. There are multiple ways to set up such a cluster; one example is to add a Windows node group to an EKS cluster as described on this [page](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html).
+
+## Running the plugin
+
+You run the plugin just like any other; there are no special requirements with it being a Windows plugin:
+
+```
+sonobuoy run --plugin plugin.yaml --wait
+```
+
+That will schedule the Sonobuoy aggregator on a Linux node and the plugin on the Windows node. If you want the Sonobuoy aggregator to also run on a Windows node, you'll need to add the `--aggregator-node-selector=kubernetes.io/os:windows` flag:
+
+```
+sonobuoy run --plugin plugin.yaml --aggregator-node-selector=kubernetes.io/os:windows --wait
+```
+
+Optionally, if you have multiple types of Windows nodes, you may need to add the node selector for the architecture as well:
+
+```
+sonobuoy run --plugin plugin.yaml --aggregator-node-selector=kubernetes.io/os:windows --aggregator-node-selector=kubernetes.io/arch:amd64 --wait
+```
+
+## Known issues
+
+If the results tarball is opened on a non-Windows machine, the resulting files/folders will be flattened awkwardly. This is because the Windows path separator is just being interpreted as part of the individual file names. As a result, you end up with folders/files like:
+
+```
+...
+should\be\a\series\of\nested\folders
+should\be\a\series\of\nested\folders\file-in-folder
+...
+```
+
+We are open to solutions for this problem; for the time being it is easy to tolerate and surely has various client-side solutions.

--- a/examples/plugins/windows-plugin/plugin.yaml
+++ b/examples/plugins/windows-plugin/plugin.yaml
@@ -1,0 +1,28 @@
+podSpec:
+  nodeSelector:
+    kubernetes.io/os: windows
+    kubernetes.io/arch: amd64
+  containers: []
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
+sonobuoy-config:
+  driver: Job
+  plugin-name: windows-events
+  result-format: raw
+  skip-cleanup: true
+spec:
+  image: sonobuoy/windows-plugin:v1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+

--- a/examples/plugins/windows-plugin/run.ps1
+++ b/examples/plugins/windows-plugin/run.ps1
@@ -1,0 +1,5 @@
+$outputFile = 'c:\tmp\results\file.txt'
+$doneFile = 'c:\tmp\results\done'
+
+Get-WinEvent > $outputFile
+$outputFile | Out-File $doneFile -Encoding ascii

--- a/manifest_spec.yaml.tmpl
+++ b/manifest_spec.yaml.tmpl
@@ -1,0 +1,17 @@
+image: REGISTRY/sonobuoy:TAG
+manifests:
+  -
+    image: REGISTRY/sonobuoy-amd64:TAG
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: REGISTRY/sonobuoy-arm64:TAG
+    platform:
+      architecture: arm64
+      os: linux
+WIN_ONLY  -
+WIN_ONLY    image: REGISTRY/sonobuoy-win-amd64:TAG
+WIN_ONLY    platform:
+WIN_ONLY      architecture: amd64
+WIN_ONLY      os: windows

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -59,6 +59,8 @@ type templateValues struct {
 	SSHKey            string
 	SSHUser           string
 
+	NodeSelectors map[string]string
+
 	// CustomRegistries should be a multiline yaml string which represents
 	// the file contents of KUBE_TEST_REPO_LIST, the overrides for k8s e2e
 	// registries.
@@ -182,6 +184,8 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 		SSHUser:           cfg.SSHUser,
 
 		Plugins: pluginYAML,
+
+		NodeSelectors: cfg.NodeSelectors,
 
 		// Often created from reading a file, this value could have trailing newline.
 		CustomRegistries: strings.TrimSpace(cfg.E2EConfig.CustomRegistries),

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -393,6 +393,22 @@ func TestGenerateManifestGolden(t *testing.T) {
 				SystemdLogsImage: "custom-systemd-logs:v1.0.0",
 			},
 			goldenFile: filepath.Join("testdata", "custom-systemd-logs-image.golden"),
+		}, {
+			name: "Node selector can be added",
+			inputcm: &client.GenConfig{
+				E2EConfig:     &client.E2EConfig{},
+				Config:        newConfigWithoutUUID(),
+				NodeSelectors: map[string]string{"foo": "bar"},
+			},
+			goldenFile: filepath.Join("testdata", "single-node-selector.golden"),
+		}, {
+			name: "Multiple node selectors can be added",
+			inputcm: &client.GenConfig{
+				E2EConfig:     &client.E2EConfig{},
+				Config:        newConfigWithoutUUID(),
+				NodeSelectors: map[string]string{"foo": "bar", "fizz": "buzz"},
+			},
+			goldenFile: filepath.Join("testdata", "multiple-node-selector.golden"),
 		},
 	}
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -82,6 +82,10 @@ type GenConfig struct {
 	// yet able to be manipulated in this way.
 	PluginEnvOverrides map[string]map[string]string
 
+	// NodeSelectors, if set, will be applied to the aggregator pod allowing it
+	// to be schedule on particular nodes.
+	NodeSelectors map[string]string
+
 	// ShowDefaultPodSpec determines whether or not the default pod spec for
 	// the plugin should be incuded in the output.
 	ShowDefaultPodSpec bool

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -1,0 +1,143 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+  plugin-1.yaml: |
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-format: raw
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+      - mountPath: /node
+        name: root
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  nodeSelector:
+    fizz: buzz
+    foo: bar
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:static-version-for-testing
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -1,0 +1,142 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+  plugin-1.yaml: |
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-format: raw
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh && while true; do echo "Sleeping for 1h to avoid daemonset
+        restart"; sleep 3600; done
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+      - mountPath: /node
+        name: root
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  nodeSelector:
+    foo: bar
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:static-version-for-testing
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -122,6 +122,10 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+{{- if .NodeSelectors }}
+  nodeSelector:{{- range $k, $v := .NodeSelectors }}
+    {{ indent 4 $k}}: {{$v}}
+{{- end }}{{- end }}
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package worker
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -87,6 +88,7 @@ func GatherResults(waitfile string, url string, client *http.Client, stopc <-cha
 		select {
 		case <-ticker:
 			if resultFile, err := ioutil.ReadFile(waitfile); err == nil {
+				resultFile = bytes.TrimSpace(resultFile)
 				logrus.WithField("resultFile", string(resultFile)).Info("Detected done file, transmitting result file")
 				return handleWaitFile(string(resultFile), url, client)
 			}

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -10,7 +10,7 @@ fi
 
 function image_push() {
     echo ${DOCKERHUB_TOKEN} | docker login --username sonobuoybot --password-stdin
-    make containers push
+    make push
 }
 
 if [ ! -z "$CIRCLE_TAG" ]; then

--- a/site/docs/master/release.md
+++ b/site/docs/master/release.md
@@ -124,3 +124,19 @@ version of the docs.
 
 [gendocs]: #generating-a-new-set-of-versioned-docs
 [dockerhub]: https://cloud.docker.com/u/sonobuoy/repository/docker/sonobuoy/sonobuoy/tags
+
+2. If you are building a Windows release you must currently build/push the Windows image outside of CI and push the manifest to also include it. To do this you must:
+
+ - Have built the Windows binaries (can be done on a Linux box and should be the default now)
+ - Have a Windows machine available for the build. The steps below will assume a `docker context` which is a Windows machine.
+ - (Recommended) Build the sample Windows plugin (in our examples directory) to test the image
+ - (Recommended) Have a cluster with Windows available for testing
+
+```
+docker context use default
+make build/windows/amd64/sonobuoy.exe
+docker context use 2019-box
+make windows_containers
+PUSH_WINDOWS=true make push
+
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in a beta state, we are experimenting with building
Windows images so that Sonobuoy can be run on Windows nodes.

This change stops short of adding the Windows build to CI
while we figure out some of the last technical problems there.

Changes include:
 - Utilizing circleci workspaces to load/store docker images across stages
 - Adds a Windows sample plugin
 - Updates the makefile to support building windows images and cleans up some of the makefile structure to build the binaries as appropriate
 - Updates the makefile to build/push images for windows only if PUSH_WINDOWS=true
 - Updates the way the manifest-tool is invoked to use a template instead of the command line options (which provides more flexibility)
 - Adds a flag `aggregator-node-selector` to gen/run commands in order to help direct where to place the aggregator in mixed-node clusters
 - Modify which command is used to grab the tarball of results from the aggregator depending on whether or not it is a Windows system or not (therefore if bash or powershell should be used)

**Which issue(s) this PR fixes**
- Related #732

**Special notes for your reviewer**:
The hardest parts of this are:
 - gettings a Windows cluster
 - getting a Windows docker context

Once those are handled the rest isn't so bad.

**Release note**:
```
Several changes related to supporting running on a Windows machine including building Windows compatible images.
```
