### PR TITLE
Add kubernetes-version flag to images subcommands

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -368,6 +368,15 @@ func AddPluginListFlag(p *[]string, flags *pflag.FlagSet) {
 	flags.StringSliceVarP(p, "plugin", "p", []string{"e2e", "systemd-logs"}, "Describe which plugin's images to interact with (Valid plugins are 'e2e', 'systemd-logs').")
 }
 
+// AddKubernetesVersionFlag adds a string flag for the user to specify the cluster version to assume instead of reaching
+// out to the cluster to auto-detect it.
+func AddKubernetesVersionFlag(version *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		version, "kubernetes-version", "",
+		fmt.Sprintf("Version to assume for Kubernetes. If empty, the cluster will be queried for its version"),
+	)
+}
+
 // AddShortFlag adds a boolean flag to just print the Sonobuoy version and
 // nothing else. Useful in scripts.
 func AddShortFlag(flag *bool, flags *pflag.FlagSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If the cluster the user wants to get images for is not available
at the time (preparing images ahead of time, for a coworker, etc)
then the user needs a way to specify the version rather than relying
on the autodetection.

This change also causes the images from `sonobuoy images` to be printed
in a sorted order for consistency.

**Which issue(s) this PR fixes**
Fixes #1082

**Special notes for your reviewer**:

**Release note**:
```
Adds a kubernetes-version flag to the images subcommands to allow manual specification instead of auto-detection of cluster version.
```
