### PR TITLE
Add a new results format: manual

### DIFF
--- a/pkg/client/results/manual.go
+++ b/pkg/client/results/manual.go
@@ -1,0 +1,75 @@
+/*
+Copyright the Sonobuoy contributors 2020
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package results
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+func manualProcessFile(pluginDir, currentFile string) (Item, error) {
+	relPath, err := filepath.Rel(pluginDir, currentFile)
+	if err != nil {
+		logrus.Errorf("Error making path %q relative to %q: %v", pluginDir, currentFile, err)
+		relPath = currentFile
+	}
+
+	rootObj := Item{
+		Name:   filepath.Base(currentFile),
+		Status: StatusUnknown,
+		Metadata: map[string]string{
+			metadataFileKey: relPath,
+			metadataTypeKey: metadataTypeFile,
+		},
+	}
+
+	infile, err := os.Open(currentFile)
+	if err != nil {
+		rootObj.Metadata["error"] = err.Error()
+		rootObj.Status = StatusUnknown
+
+		return rootObj, errors.Wrapf(err, "opening file %v", currentFile)
+	}
+	defer infile.Close()
+
+	resultObj, err := manualProcessReader(infile)
+	if err != nil {
+		return rootObj, errors.Wrap(err, "error processing manual results")
+	}
+
+	rootObj.Status = resultObj.Status
+	rootObj.Items = resultObj.Items
+
+	return rootObj, nil
+}
+
+func manualProcessReader(r io.Reader) (Item, error) {
+	resultItem := Item{}
+
+	dec := yaml.NewDecoder(r)
+	err := dec.Decode(&resultItem)
+	if err != nil {
+		return resultItem, errors.Wrap(err, "failed to parse yaml results object provided by plugin:")
+	}
+
+	return resultItem, nil
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/ds-manual-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/ds-manual-01.golden.json
@@ -1,0 +1,23 @@
+{
+"name": "ds-manual-01",
+"status": "unknown",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "node1",
+"status": "unknown",
+"meta": {
+"type": "node"
+}
+},
+{
+"name": "node2",
+"status": "unknown",
+"meta": {
+"type": "node"
+}
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/results/node1/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/results/node1/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: node1status
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/results/node2/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/results/node2/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: node2status
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/ds-manual-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/ds-manual-02.golden.json
@@ -1,0 +1,123 @@
+{
+"name": "ds-manual-02",
+"status": "status-from-manual-results-1: 2, status-from-manual-results-2: 2",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "node1",
+"status": "status-from-manual-results-1: 1, status-from-manual-results-2: 1",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "manual-results-1.yaml",
+"status": "status-from-manual-results-1",
+"meta": {
+"file": "results/node1/manual-results-1.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+},
+{
+"name": "manual-results-2.yaml",
+"status": "status-from-manual-results-2",
+"meta": {
+"file": "results/node1/manual-results-2.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+},
+{
+"name": "node2",
+"status": "status-from-manual-results-1: 1, status-from-manual-results-2: 1",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "manual-results-1.yaml",
+"status": "status-from-manual-results-1",
+"meta": {
+"file": "results/node2/manual-results-1.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+},
+{
+"name": "manual-results-2.yaml",
+"status": "status-from-manual-results-2",
+"meta": {
+"file": "results/node2/manual-results-2.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node1/manual-results-1.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node1/manual-results-1.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results-1
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node1/manual-results-2.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node1/manual-results-2.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results-2
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node2/manual-results-1.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node2/manual-results-1.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results-1
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node2/manual-results-2.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/results/node2/manual-results-2.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results-2
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/ds-manual-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/ds-manual-03.golden.json
@@ -1,0 +1,75 @@
+{
+"name": "ds-manual-03",
+"status": "status-from-manual-results",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "node1",
+"status": "status-from-manual-results",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "status-from-manual-results",
+"meta": {
+"file": "results/node1/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+},
+{
+"name": "node2",
+"status": "status-from-manual-results",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "status-from-manual-results",
+"meta": {
+"file": "results/node2/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node1/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node1/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node1/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node1/sonobuoy_results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node2/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node2/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node2/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/results/node2/sonobuoy_results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
@@ -1,0 +1,75 @@
+{
+"name": "ds-manual-04",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "node1",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "sonobuoy_results.yaml",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"file": "results/node1/sonobuoy_results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+},
+{
+"name": "node2",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"type": "node"
+},
+"items": [
+{
+"name": "sonobuoy_results.yaml",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"file": "results/node2/sonobuoy_results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node1/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node1/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node1/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node1/sonobuoy_results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node2/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node2/manual-results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node2/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/results/node2/sonobuoy_results.yaml
@@ -1,0 +1,13 @@
+name: ds-manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-01/job-manual-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-01/job-manual-01.golden.json
@@ -1,0 +1,7 @@
+{
+"name": "job-manual-01",
+"status": "unknown",
+"meta": {
+"type": "summary"
+}
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-01/results/global/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-01/results/global/manual-results.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: custom aggregate status
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-02/job-manual-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-02/job-manual-02.golden.json
@@ -1,0 +1,69 @@
+{
+"name": "job-manual-02",
+"status": "custom status: 1, different custom status: 1",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "manual-results-1.yaml",
+"status": "different custom status",
+"meta": {
+"file": "results/global/manual-results-1.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
+}
+]
+}
+]
+}
+]
+},
+{
+"name": "manual-results-2.yaml",
+"status": "custom status",
+"meta": {
+"file": "results/global/manual-results-2.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "Another test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_02.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-02/results/global/manual-results-1.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-02/results/global/manual-results-1.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: different custom status
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-02/results/global/manual-results-2.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-02/results/global/manual-results-2.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: custom status
+meta:
+  type: summary
+items:
+- name: Another test file
+  status: status 1
+  meta:
+    file: results/global/junit_02.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-03/job-manual-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-03/job-manual-03.golden.json
@@ -1,0 +1,39 @@
+{
+"name": "job-manual-03",
+"status": "status-from-manual-results",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "status-from-manual-results",
+"meta": {
+"file": "results/global/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-03/results/global/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-03/results/global/manual-results.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-03/results/global/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-03/results/global/sonobuoy_results.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
@@ -1,0 +1,39 @@
+{
+"name": "job-manual-04",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"type": "summary"
+},
+"items": [
+{
+"name": "sonobuoy_results.yaml",
+"status": "status-from-default-sonobuoy-results",
+"meta": {
+"file": "results/global/sonobuoy_results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
+}
+]
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-04/results/global/manual-results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-04/results/global/manual-results.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: status-from-manual-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-04/results/global/sonobuoy_results.yaml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-04/results/global/sonobuoy_results.yaml
@@ -1,0 +1,16 @@
+name: manual-plugin
+status: status-from-default-sonobuoy-results
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test name
+      status: passed

--- a/test/integration/testImage/resources/manual-results-1.yaml
+++ b/test/integration/testImage/resources/manual-results-1.yaml
@@ -1,0 +1,18 @@
+name: custom
+status: manual-results-1
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test
+      status: passed
+    - name: Another manual test
+      status: failed

--- a/test/integration/testImage/resources/manual-results-2.yaml
+++ b/test/integration/testImage/resources/manual-results-2.yaml
@@ -1,0 +1,18 @@
+name: custom
+status: manual-results-2
+meta:
+  type: summary
+items:
+- name: a test file
+  status: status 1
+  meta:
+    file: results/global/junit_01.xml
+    type: file
+  items:
+  - name: Manual suite name
+    status: status 2
+    items:
+    - name: Manual test
+      status: passed
+    - name: Another manual test
+      status: custom-status

--- a/test/integration/testImage/src/tarResults.go
+++ b/test/integration/testImage/src/tarResults.go
@@ -35,14 +35,17 @@ var cmdTarFile = &cobra.Command{
 }
 
 func reportTarFile(cmd *cobra.Command, args []string) error {
-	outpath := os.TempDir()
-	fmt.Printf("Using tmp dir %v for results. Will remove them after tarring the results\n", outpath)
-	defer os.RemoveAll(outpath)
+	tmpDir := os.TempDir()
+	outPath, err := ioutil.TempDir(tmpDir, "sonobuoy-integration")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create outPath dir %v", outPath)
+	}
+	fmt.Printf("Using tmp dir %v for results. Will remove them after tarring the results\n", outPath)
+	defer os.RemoveAll(outPath)
 
 	for _, f := range args {
 		targetFile := f
-		resultsFile := filepath.Join(outpath, filepath.Base(targetFile))
-
+		resultsFile := filepath.Join(outPath, filepath.Base(targetFile))
 		// Copy file to location Sonobuoy can get it.
 		_, err := copyFile(targetFile, resultsFile)
 		if err != nil {
@@ -52,7 +55,7 @@ func reportTarFile(cmd *cobra.Command, args []string) error {
 
 	// Create tarball.
 	tb := filepath.Join(resultsDir, "results.tar.gz")
-	err := tarx.Compress(tb, outpath, &tarx.CompressOptions{Compression: tarx.Gzip})
+	err = tarx.Compress(tb, outPath, &tarx.CompressOptions{Compression: tarx.Gzip})
 	if err != nil {
 		return errors.Wrap(err, "failed to create tarball")
 	}

--- a/test/integration/testImage/yaml/ds-manual.yaml
+++ b/test/integration/testImage/yaml/ds-manual.yaml
@@ -1,0 +1,21 @@
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: ds-manual
+  result-format: manual
+  result-files:
+    - manual-results-1.yaml
+    - manual-results-2.yaml
+spec:
+  args:
+  - tar-file
+  - /resources/manual-results-1.yaml
+  - /resources/manual-results-2.yaml
+  command:
+  - testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+

--- a/test/integration/testImage/yaml/job-manual.yaml
+++ b/test/integration/testImage/yaml/job-manual.yaml
@@ -1,0 +1,21 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: job-manual
+  result-format: manual
+  result-files:
+    - manual-results-1.yaml
+    - manual-results-2.yaml
+spec:
+  args:
+  - tar-file
+  - /resources/manual-results-1.yaml
+  - /resources/manual-results-2.yaml
+  command:
+  - testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual results allow a user to write the sonobuoy_results.yaml
file largely on their own.

Due to some limitations we still wrap their file with one more
summary level item.

When the user gave us a single top-level item, the status from that
item is used for the summary. Otherwise all the top level items
are considered and a non-judgemental routine just counts the various
status values and shows them as a human readable status for the
top level. This helps ensure that the status value from custom output
can be various pieces of info the user may want to provide and not just
something like 'pass' or 'fail'.

**Release note**:
```
Sonobuoy now supports plugins providing their own results using the Sonobuoy results format. These results will be post-processed by Sonobuoy for inclusion in the `results` workflow. Sonobuoy will post-process any file listed in a plugin configuration under `result-files` or, if not provided, a `sonobuoy_results.yaml` file.
```
