### PR TITLE
Attach workspace before loading docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
       enabled: true
     steps:
       - checkout
+      - attach_workspace:
+          at: /home/circleci/project
       - run:
           name: Load images into docker from workspace
           command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Our CI is failing because we are not attaching the workspace where the
Docker images were built before attempting to load them. This change
attaches the workspace before attempting to load the images as we do in
the integration test step.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
