### PR TITLE
Remove deprecated --systemd-logs-flag flag

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -107,16 +107,6 @@ func AddSystemdLogsImage(image *string, flags *pflag.FlagSet) {
 		image, "systemd-logs-image", config.DefaultSystemdLogsImage,
 		"Container image override for the systemd-logs plugin image.",
 	)
-
-	// The flag for overriding the systemd-logs image was mistakenly defined as
-	// systemd-logs-flag. This flag remains but is marked as hidden and deprecated
-	// to prevent breaking the behaviour for existing users.
-	flags.StringVar(
-		image, "systemd-logs-flag", config.DefaultSystemdLogsImage,
-		"Container image override for the systemd-logs plugin image.",
-	)
-	flags.MarkHidden("systemd-logs-flag")
-	flags.MarkDeprecated("systemd-logs-flag", "please use --systemd-logs-image instead")
 }
 
 // AddKubeConformanceImageVersion initialises an image version flag.


### PR DESCRIPTION
**What this PR does / why we need it**:
In #1066, we deprecated this flag with the intention of removing it in
the 0.18.0 release. Given that we are about to release this version,
this flag is now being removed.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1067 



**Release note**:
```
Remove the deprecated `--systemd-logs-flag` flag. `--systemd-logs-image` should be used instead.
```
