### PR TITLE
Persist images for all targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: Save as tar files to persist to next step
           command: |
-            docker save -o sonobuoyImages.tar.gz sonobuoy/sonobuoy
+            docker save -o sonobuoyImages.tar.gz sonobuoy/sonobuoy sonobuoy/sonobuoy-amd64 sonobuoy/sonobuoy-arm64
       - persist_to_workspace:
           root: /home/circleci/project
           paths:


### PR DESCRIPTION
**What this PR does / why we need it**:
[When building the Sonobuoy images, we build images for multiple targets.
We push them in a separate step from where they were built so they need
to be persisted to the workspace. We were previously only persisting the
sonobuoy/sonobuoy tagged images, not the sonobuoy/sonobuoy-ARCH images.
This was causing CI failures as the image pushing step was trying to
push images for different architectures that did not exist locally.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

