### PR TITLE
Use passed VERSION when generating image manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ vet:
 	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(VET)'
 
 pre:
-	wget https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64 \
+	wget https://github.com/estesp/manifest-tool/releases/download/v1.0.1/manifest-tool-linux-amd64 \
 	  -O manifest-tool && \
 	 chmod +x ./manifest-tool
 	echo $(DOCKERHUB_TOKEN) | docker login --username sonobuoybot --password-stdin
@@ -189,13 +189,13 @@ gen_manifest:
 	mkdir -p build
 
 ifeq ($(PUSH_WINDOWS),true)
-	sed -e 's|TAG|$(IMAGE_VERSION)|g' \
+	sed -e 's|TAG|$(VERSION)|g' \
 	-e 's|REGISTRY|$(REGISTRY)|g' \
 	-e 's/WIN_ONLY//g' \
 	manifest_spec.yaml.tmpl > ./build/manifest_spec.yaml;
 else
 	echo '$$PUSH_WINDOWS not set, not including Windows in manifest'
-	sed -e 's|TAG|$(IMAGE_VERSION)|g' \
+	sed -e 's|TAG|$(VERSION)|g' \
 	-e 's|REGISTRY|$(REGISTRY)|g' \
 	-e '/^WIN_ONLY/d' \
 	manifest_spec.yaml.tmpl > ./build/manifest_spec.yaml;


### PR DESCRIPTION
**What this PR does / why we need it**:
When calling the `push_manifest` target, we were passing `VERSION` to
use for the image tag, however it wasn't being used. Instead we using
the `IMAGE_VERSION` which was defined outside the target and was the tag
for an image that hadn't been pushed. This modifies the `gen_manifest`
target to use the passed `VERSION` value.

This also updates our Makefile to get the latest version of
manifest-tool.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>