### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,16 @@ Sonobuoy supports 3 Kubernetes minor versions: the current release and 2 minor v
 
 * The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed. See [installing Docker](docker).
 
-## Installing
+## Installation
 
-We recommend installing Sonobuoy via downloading one of the releases directly from [here][releases].
+1. Download the [latest release][releases] for your client platform.
+2. Extract the tarball:
 
-You can use the web UI to download a release or from the terminal:
+   ```
+   tar -xvf <RELEASE_TARBALL_NAME>.tar.gz
+   ```
 
-```
-$ VERSION=0.16.1 OS=darwin && \
-    curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_amd64.tar.gz" --output $HOME/bin/sonobuoy.tar.gz && \
-    tar -xzf $HOME/bin/sonobuoy.tar.gz -C $HOME/bin && \
-    chmod +x $HOME/bin/sonobuoy && \
-    rm $HOME/bin/sonobuoy.tar.gz
-```
-
-> Note: Be sure to update the OS to your local value. Supported values are: "linux", "darwin", and "windows".
-
-If building locally, you should clone the repository and run `make`. To build locally, Docker is required.
+   Move the extracted `sonobuoy` executable to somewhere on your `PATH`.
 
 ## Getting Started
 

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -31,23 +31,16 @@ Sonobuoy supports 3 Kubernetes minor versions: the current release and 2 minor v
 
 * The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed. See [installing Docker](docker).
 
-## Installing
+## Installation
 
-We recommend installing Sonobuoy via downloading one of the releases directly from [here][releases].
+1. Download the [latest release][releases] for your client platform.
+2. Extract the tarball:
 
-You can use the web UI to download a release or from the terminal:
+   ```
+   tar -xvf <RELEASE_TARBALL_NAME>.tar.gz
+   ```
 
-```
-$ VERSION=0.16.1 OS=darwin && \
-    curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_amd64.tar.gz" --output $HOME/bin/sonobuoy.tar.gz && \
-    tar -xzf $HOME/bin/sonobuoy.tar.gz -C $HOME/bin && \
-    chmod +x $HOME/bin/sonobuoy && \
-    rm $HOME/bin/sonobuoy.tar.gz
-```
-
-> Note: Be sure to update the OS to your local value. Supported values are: "linux", "darwin", and "windows".
-
-If building locally, you should clone the repository and run `make`. To build locally, Docker is required.
+   Move the extracted `sonobuoy` executable to somewhere on your `PATH`.
 
 ## Getting Started
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Our installation instructions included a command to download and extract
a release tarball from GitHub. This command assumed the presence of
`$HOME/bin` which not all users had. It also assumed that users will be
downloading an `amd64` release.

Now that we are supporting many more platforms and architectures, it is
simpler to leave it up to the user to select the release they want and
extract it to their desired location.

Also, due to the increased changes to the platforms we support, and the
new workflows for building images for those targets, we don't recommend
building from source so remove that as a suggestion.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #980 