### PR TITLE
Use v1.18.0 kind image

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -2,8 +2,8 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
-  image: sonobuoy/kind-node:v1.17.0
+  image: sonobuoy/kind-node:v1.18.0
 - role: worker
-  image: sonobuoy/kind-node:v1.17.0
+  image: sonobuoy/kind-node:v1.18.0
 - role: worker
-  image: sonobuoy/kind-node:v1.17.0
+  image: sonobuoy/kind-node:v1.18.0


### PR DESCRIPTION
This step was missing from the PR for the v0.18.0 release (#1101).