### PR TITLE
Ensure all CI steps are run for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,13 +122,28 @@ workflows:
   version: 2
   checks:
     jobs:
-      - check_go_mod
-      - check_readme_sync
-      - build_clients
-      - unit_tests
+      - check_go_mod:
+          filters:
+            tags:
+              only: /^v.*/
+      - check_readme_sync:
+          filters:
+            tags:
+              only: /^v.*/
+      - build_clients:
+          filters:
+            tags:
+              only: /^v.*/
+      - unit_tests:
+          filters:
+            tags:
+              only: /^v.*/
       - build_containers:
           requires:
             - build_clients
+          filters:
+            tags:
+              only: /^v.*/
       - integration_tests:
           requires:
             - build_clients


### PR DESCRIPTION
**What this PR does / why we need it**:
As stated in the [CircleCI docs](https://circleci.com/docs/2.0/configuration-reference/#tags), if a job has a tag filter, all dependent jobs
must have the same tag filter. Given that the `publish_images` job
depends on all the other jobs, these must also have the same tag filter.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>