### PR TITLE
Fix missing registry for E2E test image

### DIFF
--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -85,6 +85,7 @@ func NewRegistryList(repoConfig, k8sVersion string) (*RegistryList, error) {
 		QuayIncubator:           quayIncubator,
 		QuayK8sCSI:              quayK8sCSI,
 		SampleRegistry:          sampleRegistry,
+		PromoterE2eRegistry:     promoterE2eRegistry,
 	}
 
 	// Load in a config file


### PR DESCRIPTION
**What this PR does / why we need it**:
The `PromoterE2eRegistry` wasn't set correctly which
resulted in an invalid image in the E2E images list.

