### PR TITLE
Upgrade to Kind 0.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run:
           name: "Install kind"
           command: |
-            curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-linux-amd64 --output kind
+            curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 --output kind
             chmod +x ./kind
             sudo mv ./kind /usr/local/bin
             curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output jq 
@@ -100,7 +100,6 @@ jobs:
           name: "Create kind cluster"
           command: |
             kind create cluster --config kind-config.yaml
-            echo 'export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"' >> $BASH_ENV
       - attach_workspace:
           at: /home/circleci/project
       - run:

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -20,4 +20,4 @@ kind load docker-image --name $cluster $testImage
 
 # Build and load the sonobuoy image and run integration tests
 make -C $DIR KIND_CLUSTER=$cluster deploy_kind
-KUBECONFIG="$(kind get kubeconfig-path --name="$cluster")" VERBOSE=true make -C $DIR int
+KUBECONFIG=${HOME}/.kube/config VERBOSE=true make -C $DIR int

--- a/site/docs/master/release.md
+++ b/site/docs/master/release.md
@@ -99,12 +99,16 @@ working appropriately:
 1. Go to the [GitHub release page](https://github.com/vmware-tanzu/sonobuoy/releases) and download the release binaries and make sure the version matches the expected values.
 2. Run a [Kind](https://github.com/kubernetes-sigs/kind) cluster locally and ensure that you can run `sonobuoy run --mode quick`.
    If this release corresponds to a new Kubernetes release as well, ensure:
+    - you're using the correct Kubernetes context by checking the output from:
+      ```
+      kubectl config current-context
+      ```
+      and verifying that it is set to the context for the Kind cluster just created (`kind-kind` or `kind-<custom_cluster_name>`)
     - you're testing with the new Kind images by checking the output from:
       ```
-      export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
       kubectl version --short
       ```
-      and verify that the server version matches the intended Kubernetes version.
+      and verifying that the server version matches the intended Kubernetes version.
     - you can run `sonobuoy images` and get a list of test images as expected
 2. Update the release notes if desired on GitHub by editing the newly created release.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This upgrades our use of Kind in CI to the latest version. A recent
version of Kind introduced merging of kubeconfigs and separate
kubeconfigs are no longer written. The kind command
`get kubeconfig-path` has been deprecated so any usage of it has
been removed. The context is be updated to use the newly created
cluster. Some of our docs which reference this deprecated command
have also been updated.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
