### PR TITLE
Upgrade to Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   check_go_mod:
     docker:
-      - image: golang:1.13
+      - image: golang:1.14
     steps:
       - checkout
       - run:
@@ -12,7 +12,7 @@ jobs:
 
   check_readme_sync:
     docker:
-      - image: golang:1.13
+      - image: golang:1.14
     steps:
       - checkout
       - run:
@@ -21,7 +21,7 @@ jobs:
 
   github-release:
     docker:
-      - image: circleci/golang:1.13.1
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.13.0-stretch
+BUILD_IMAGE ?= golang:1.14-stretch
 AMD_IMAGE ?= debian:stretch-slim
 ARM_IMAGE ?= arm64v8/ubuntu:16.04
 WIN_IMAGE ?= mcr.microsoft.com/windows/servercore:1809

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/sonobuoy
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.41.0 // indirect

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.0-stretch AS base
+FROM golang:1.14-stretch AS base
 WORKDIR /src
 
 # Handle the go modules first to take advantage of Docker cache.

--- a/test/integration/testImage/src/go.mod
+++ b/test/integration/testImage/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/sonobuoy/test/integration/testImage/src
 
-go 1.13
+go 1.14
 
 require (
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Update our base images, go.mod files, and CircleCI config
to use the latest version of Go.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
