### PR TITLE
Add verbose flag when creating kind cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: "Create kind cluster"
           command: |
-            kind create cluster --config kind-config.yaml
+            kind create cluster --config kind-config.yaml -v 1
       - attach_workspace:
           at: /home/circleci/project
       - run:


### PR DESCRIPTION
**What this PR does / why we need it**:
We're seeing frequent failures when attempting to create a kind
cluster in our CircleCI scripts. This increases the verbosity when
running kind to help debug the issue.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>




