### PR TITLE
Add GitHub links to team member list

### DIFF
--- a/site/_contributors/01-john-schnake.md
+++ b/site/_contributors/01-john-schnake.md
@@ -2,5 +2,6 @@
 first_name: John
 last_name: Schnake
 image: /img/contributors/john-schnake.png
+github_handle: johnSchnake
 ---
 Tech Lead

--- a/site/_contributors/02-bridget-mcerlean.md
+++ b/site/_contributors/02-bridget-mcerlean.md
@@ -2,5 +2,6 @@
 first_name: Bridget
 last_name: McErlean
 image: /img/contributors/bridget-mcerlean.png
+github_handle: zubron
 ---
 Engineer

--- a/site/_contributors/02-steve-sloka.md
+++ b/site/_contributors/02-steve-sloka.md
@@ -2,5 +2,6 @@
 first_name: Steve
 last_name: Sloka
 image: /img/contributors/steve-sloka.png
+github_handle: stevesloka
 ---
 Engineer

--- a/site/_contributors/03-tim-hinderliter.md
+++ b/site/_contributors/03-tim-hinderliter.md
@@ -2,5 +2,6 @@
 first_name: Tim
 last_name: Hinderliter
 image: /img/contributors/tim-hinderliter.png
+github_handle: timh
 ---
 Engineering Manager

--- a/site/_contributors/04-michael-michael.md
+++ b/site/_contributors/04-michael-michael.md
@@ -2,5 +2,6 @@
 first_name: Michael
 last_name: Michael
 image: /img/contributors/michael-michael.png
+github_handle: michmike
 ---
 Product Manager

--- a/site/_includes/contributors.html
+++ b/site/_includes/contributors.html
@@ -16,7 +16,7 @@
       <div class="media thumbnail-item">
         <img src="{{ person.image }}" class="rounded-circle" alt="Person" />
         <div class="media-body align-self-center">
-          <h6><a href="#">{{ person.first_name }} {{ person.last_name }}</a></h6>
+          <h6><a href="https://github.com/{{ person.github_handle }}">{{ person.first_name }} {{ person.last_name }}</a></h6>
         {{ person.content | markdownify }}    
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: jonasrosland <jrosland@vmware.com>


**What this PR does / why we need it**:
This will change the non-relevant links for each team member to proper links to GitHub user pages.

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
