### PR TITLE
Change default value for E2E_PARALLEL

### DIFF
--- a/cmd/sonobuoy/app/args_test.go
+++ b/cmd/sonobuoy/app/args_test.go
@@ -38,16 +38,16 @@ func TestGetE2EConfig(t *testing.T) {
 			flagArgs: []string{},
 			expect: &ops.E2EConfig{
 				Focus:    `\[Conformance\]`,
-				Parallel: "1",
+				Parallel: "false",
 			},
 		}, {
 			desc:     "Flags settable",
 			mode:     "certified-conformance",
-			flagArgs: []string{"--e2e-focus=foo", "--e2e-skip=bar", "--e2e-parallel=2"},
+			flagArgs: []string{"--e2e-focus=foo", "--e2e-skip=bar", "--e2e-parallel=true"},
 			expect: &ops.E2EConfig{
 				Focus:    `foo`,
 				Skip:     `bar`,
-				Parallel: "2",
+				Parallel: "true",
 			},
 		}, {
 			desc:      "Focus regexp validated settable",

--- a/pkg/client/mode.go
+++ b/pkg/client/mode.go
@@ -87,7 +87,7 @@ func (m *Mode) Get() *ModeConfig {
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
 				Focus:    `\[Conformance\]`,
-				Parallel: "1",
+				Parallel: "false",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},
@@ -99,7 +99,7 @@ func (m *Mode) Get() *ModeConfig {
 			E2EConfig: E2EConfig{
 				Focus:    `\[Conformance\]`,
 				Skip:     nonDisruptiveSkipList,
-				Parallel: "1",
+				Parallel: "false",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},
@@ -110,7 +110,7 @@ func (m *Mode) Get() *ModeConfig {
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
 				Focus:    "Pods should be submitted and removed",
-				Parallel: "1",
+				Parallel: "false",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},


### PR DESCRIPTION
**What this PR does / why we need it**:
The original implementation for enabling parallel running of tests was
added when ginkgo expected a numeric value for the number of nodes to
use when running in parallel. This is no longer needed as ginkgo can
detect the optimal number of nodes to use. The [script for running the
e2e tests](https://github.com/kubernetes/kubernetes/blob/v1.18.3/cluster/images/conformance/run_e2e.sh#L55-L61) now expects "true", "y" or "Y" to enable parallel testing.
This commmit changes the default value to "false". Although the previous
value would not have resulted in parallel testing being enabled, this
change helps users understand that the value provided should be boolean.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Release note**:
```
The default value for E2E_PARALLEL has been changed to "false" as the upstream script that consumes the value expects it to be boolean.
```
