### PR TITLE
Improve E2E namespace cleanup when using `delete --all`

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -266,7 +266,7 @@ func AddSkipPreflightFlag(flag *bool, flags *pflag.FlagSet) {
 func AddDeleteAllFlag(flag *bool, flags *pflag.FlagSet) {
 	flags.BoolVar(
 		flag, "all", false,
-		"In addition to deleting Sonobuoy namespaces, also clean up dangling e2e- namespaces.",
+		"In addition to deleting Sonobuoy namespaces, also clean up dangling e2e namespaces (those with 'e2e-framework' and 'e2e-run' labels).",
 	)
 }
 

--- a/pkg/client/delete_test.go
+++ b/pkg/client/delete_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package client
 
 import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"testing"
 )
@@ -58,6 +60,77 @@ func TestDeleteInvalidConfig(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tc.expectedErrorMsg) {
 					t.Errorf("Expected error to contain '%v', got '%v'", tc.expectedErrorMsg, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestIsE2ENamespace(t *testing.T) {
+	testcases := []struct {
+		desc           string
+		ns             v1.Namespace
+		expectedResult bool
+	}{
+		{
+			desc:           "Namespace with no labels is not classified as E2E namespace",
+			ns:             v1.Namespace{},
+			expectedResult: false,
+		},
+		{
+			desc: "Namespace with non E2E labels is not classified as E2E namespace",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"non-e2e-label": "some value",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "Namespace with only e2e-framework label is not classified as E2E namespace",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"non-e2e-label": "some value",
+						"e2e-framework": "statefulset",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "Namespace with only e2e-run label is not classified as E2E namespace",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"non-e2e-label": "some value",
+						"e2e-run":       "32c0b368-bacb-447e-8a66-03ea70a1be72",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "Namespace with e2e-framework and e2e-run labels is classified as E2E namespace",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"non-e2e-label": "some value",
+						"e2e-framework": "statefulset",
+						"e2e-run":       "32c0b368-bacb-447e-8a66-03ea70a1be72",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := isE2ENamespace(tc.ns)
+			if result != tc.expectedResult {
+				t.Errorf("expected e2e namespace classification for namespace with labels %v to be %v, got %v", tc.ns.Labels, tc.expectedResult, result)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Namespaces created by the E2E tests stopped using the `e2e-tests-`
prefix from Kubernetes 1.14 onwards. This meant that the `delete --all`
behaviour did not delete any orphaned E2E test namespaces.

This change adapts the heuristic used by Sonobuoy to find E2E namespaces
to instead look for the presence of the `e2e-framework` and `e2e-run`
labels.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1125

**Release note**:
```
The `delete --all` command will now identify namespaces for deletion by checking for the presence of the `e2e-framework` and `e2e-run` labels instead of the `e2e-` name prefix.
```
