### PR TITLE
Update args.go

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -283,7 +283,7 @@ func AddDeleteWaitFlag(flag *int, flags *pflag.FlagSet) {
 func AddRunWaitFlag(flag *int, flags *pflag.FlagSet) {
 	flags.IntVar(
 		flag, "wait", 0,
-		"How long (in minutes) to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. The default is 1 day.",
+		"How long (in minutes) to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. If specified, the default wait time is 1 day.",
 	)
 	flags.Lookup("wait").NoOptDefVal = "1440"
 }

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -283,7 +283,7 @@ func AddDeleteWaitFlag(flag *int, flags *pflag.FlagSet) {
 func AddRunWaitFlag(flag *int, flags *pflag.FlagSet) {
 	flags.IntVar(
 		flag, "wait", 0,
-		"Wait for sonobuoy run to be completed (or fail). 0 indicates do not wait. By providing --wait the default is to wait for 1 day.",
+		"How long (in minutes) to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. The default is 1 day.",
 	)
 	flags.Lookup("wait").NoOptDefVal = "1440"
 }


### PR DESCRIPTION
add unit to --wait description.

**What this PR does / why we need it**:

fixes missing default units for one of the cmd line help options

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:
minor patch so didnt make an issue.

**Release note**:
```
release-note
```
