### PR TITLE
Remove alias for aggregator command

### DIFF
--- a/cmd/sonobuoy/app/aggregator.go
+++ b/cmd/sonobuoy/app/aggregator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/vmware-tanzu/sonobuoy/pkg/discovery"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -49,9 +50,6 @@ func NewCmdAggregator() *cobra.Command {
 		},
 		Hidden: true,
 		Args:   cobra.ExactArgs(0),
-
-		// Original command but no longer used. Kept for backward compatibility.
-		Aliases: []string{"master"},
 	}
 	cmd.PersistentFlags().BoolVar(
 		&input.noExit, "no-exit", false,


### PR DESCRIPTION
**What this PR does / why we need it**:
We renamed the `master` command to `aggregator` in #847 (released in
v0.15.3) but left the previous command there as an alias. Given that we
have had 3 minor releases since this and have phased out all use, we
can remove this alias.

Also rename the file to match the new command name.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Release note**:
```
Removed the "master" alias from the aggregator command.
```
