### PR TITLE
Deprecate use of "master" in resource labels and names

### DIFF
--- a/pkg/client/testdata/custom-systemd-logs-image.golden
+++ b/pkg/client/testdata/custom-systemd-logs-image.golden
@@ -69,6 +69,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -109,8 +110,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -118,5 +119,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -87,6 +87,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -127,8 +128,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -136,5 +137,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -112,6 +112,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -152,8 +153,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -161,5 +162,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -87,6 +87,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -127,8 +128,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -136,5 +137,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -58,6 +58,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -98,8 +99,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -107,5 +108,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -61,6 +61,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -101,8 +102,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -110,5 +111,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -61,6 +61,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -101,8 +102,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -110,5 +111,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -61,6 +61,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -101,8 +102,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -110,5 +111,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -61,6 +61,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -101,8 +102,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -110,5 +111,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -56,6 +56,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -96,8 +97,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -105,5 +106,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -58,6 +58,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -100,8 +101,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -109,5 +110,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -65,6 +65,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -105,8 +106,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -114,5 +115,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -75,6 +75,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -115,8 +116,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -124,5 +125,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -46,6 +46,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -86,8 +87,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -95,5 +96,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -58,6 +58,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -98,8 +99,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -107,5 +108,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -87,6 +87,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -130,8 +131,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -139,5 +140,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/no-plugins-via-selection.golden
+++ b/pkg/client/testdata/no-plugins-via-selection.golden
@@ -38,6 +38,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -78,8 +79,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -87,5 +88,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -53,6 +53,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -93,8 +94,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -102,5 +103,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -87,6 +87,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -129,8 +130,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -138,5 +139,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -82,6 +82,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -122,8 +123,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -131,5 +132,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -68,6 +68,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: sonobuoy
@@ -108,8 +109,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: sonobuoy
 spec:
   ports:
@@ -117,5 +118,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -48,6 +48,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: 
@@ -88,8 +89,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: 
 spec:
   ports:
@@ -97,5 +98,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -118,10 +118,11 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 		annotations[k] = v
 	}
 	labels := map[string]string{
-		"component":       "sonobuoy",
-		"tier":            "analysis",
-		"sonobuoy-run":    p.SessionID,
-		"sonobuoy-plugin": p.GetName(),
+		"component":          "sonobuoy",
+		"sonobuoy-component": "plugin",
+		"sonobuoy-plugin":    p.GetName(),
+		"sonobuoy-run":       p.SessionID,
+		"tier":               "analysis",
 	}
 
 	ds.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -85,10 +85,11 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 		annotations[k] = v
 	}
 	labels := map[string]string{
-		"component":       "sonobuoy",
-		"tier":            "analysis",
-		"sonobuoy-run":    p.SessionID,
-		"sonobuoy-plugin": p.GetName(),
+		"component":          "sonobuoy",
+		"sonobuoy-component": "plugin",
+		"sonobuoy-plugin":    p.GetName(),
+		"sonobuoy-run":       p.SessionID,
+		"tier":               "analysis",
 	}
 
 	pod.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -113,6 +113,7 @@ metadata:
   labels:
     component: sonobuoy
     run: sonobuoy-master
+    sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
   namespace: {{.Namespace}}
@@ -177,8 +178,8 @@ kind: Service
 metadata:
   labels:
     component: sonobuoy
-    run: sonobuoy-master
-  name: sonobuoy-master
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
   namespace: {{.Namespace}}
 spec:
   ports:
@@ -186,6 +187,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: sonobuoy-master
+    sonobuoy-component: aggregator
   type: ClusterIP
 `)


### PR DESCRIPTION
**What this PR does / why we need it**:
We renamed the `master` command to `aggregator` in #847 (released in
v0.15.3). However, `master` was still being used in some of our
Kubernetes resource labels and names. We want to remove use of
insensitive language and as such use different labels for
identifying resources.

Now, any aggregator resources will have the label
`sonobuoy-component: aggregator` and plugin resources will have
`sonobuoy-component: plugin`. The existing label is still in place as it
was used to identify the aggregator pod (which is required most sonobuoy
commands once a run has started). Removing it now would prevent users
with older clients from using newer images, or querying the state of
runs started by newer clients. Instead, both labels will be applied
howeve the `sonobuoy-component: aggregator` label is the preferred
label. If the aggregator pod cannot be found using the new label, the
client will retry using the now deprecated label. When retrying, the
client will display a warning that it is attempting to find the pod
using the deprecated label.

Newer clients will be able to query the state of runs with old labels
applied, and older clients will be able to query the state of runs
created by the newer clients.

The name of the service created by Sonobuoy has been renamed to
`sonobuoy-aggregator`. This has no user facing impact.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Release note**:
```
The label for identifying the aggregator pod is now `sonobuoy-component: aggregator` (replacing `run: sonobuoy-master`). The label `run: sonobuoy-master` is still applied but is now deprecated and its use will be removed in a later release. Once removed, older clients will not be able to query runs started by newer versions of Sonobuoy which do not use this label. A warning about the deprecated label will now be printed if using a newer client to query a run by an older version.
```
