### PR TITLE
Remove unused config file handling from worker

### DIFF
--- a/pkg/worker/config.go
+++ b/pkg/worker/config.go
@@ -17,9 +17,8 @@ limitations under the License.
 package worker
 
 import (
-	"os"
-
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
@@ -38,16 +37,6 @@ func setConfigDefaults(ac *plugin.WorkerConfig) {
 func LoadConfig() (*plugin.WorkerConfig, error) {
 	config := &plugin.WorkerConfig{}
 	var err error
-
-	viper.SetConfigType("json")
-	viper.SetConfigName("worker")
-	viper.AddConfigPath("/etc/sonobuoy")
-	viper.AddConfigPath(".")
-
-	// Allow specifying a custom config file via the SONOBUOY_CONFIG env var
-	if forceCfg := os.Getenv("SONOBUOY_CONFIG"); forceCfg != "" {
-		viper.SetConfigFile(forceCfg)
-	}
 
 	viper.BindEnv("masterurl", "MASTER_URL")
 	viper.BindEnv("nodename", "NODE_NAME")


### PR DESCRIPTION
**What this PR does / why we need it**:
The `LoadConfig` function for the worker was configured to be able to
load configuration data from a file. However, the [necessary viper
function](https://github.com/spf13/viper/blob/13df72109047b6ae9c907bce81e327265d6d8a9c/viper.go#L1325-L1354) to load and read the file was never called. This functionality
has not worked since the initial commit and so it doesn't seem
necessary. This is now being removed in favour of only configuring the
worker via environment variables.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>