### PR TITLE
Replace use of master in Windows Dockerfile

### DIFF
--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -17,4 +17,4 @@ MAINTAINER John Schnake "jschnake@vmware.com"
 
 ADD BINARY /sonobuoy.exe
 WORKDIR /
-CMD /sonobuoy.exe master --no-exit -v 3 --logtostderr
+CMD /sonobuoy.exe aggregator --no-exit -v 3 --logtostderr


### PR DESCRIPTION
**What this PR does / why we need it**:
The `master` alias for the `aggregator` command was removed in #1137,
however this alias was still in use in the Windows Dockerfile. Replace
the use of this with the new command name `aggregator`.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>
