### PR TITLE
Remove use of gcr.io/google-containers

### DIFF
--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -58,15 +58,15 @@ func TestResolveConformanceImage(t *testing.T) {
 		}, {
 			name:             "v1.14.1 and after uses upstream and major.minor.patch",
 			requestedVersion: "v1.14.1",
-			expected:         "gcr.io/google-containers/conformance:v1.14.1",
+			expected:         "k8s.gcr.io/conformance:v1.14.1",
 		}, {
 			name:             "v1.14.0 and after uses upstream and major.minor.patch",
 			requestedVersion: "v1.15.1",
-			expected:         "gcr.io/google-containers/conformance:v1.15.1",
+			expected:         "k8s.gcr.io/conformance:v1.15.1",
 		}, {
 			name:             "latest should use upstream image",
 			requestedVersion: "latest",
-			expected:         "gcr.io/google-containers/conformance:latest",
+			expected:         "k8s.gcr.io/conformance:latest",
 		}, {
 			name:             "explicit version before v1.14.0 should use heptio image and given version",
 			requestedVersion: "v1.12+.0.alpha+",
@@ -74,7 +74,7 @@ func TestResolveConformanceImage(t *testing.T) {
 		}, {
 			name:             "explicit version after v1.14.0 should use upstream and use given version",
 			requestedVersion: "v1.14.1",
-			expected:         "gcr.io/google-containers/conformance:v1.14.1",
+			expected:         "k8s.gcr.io/conformance:v1.14.1",
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ const (
 	DefaultKubeConformanceImageURL = "gcr.io/heptio-images/kube-conformance"
 	// UpstreamKubeConformanceImageURL is the URL of the docker image to run for
 	// the kube conformance tests which is maintained by upstream Kubernetes.
-	UpstreamKubeConformanceImageURL = "gcr.io/google-containers/conformance"
+	UpstreamKubeConformanceImageURL = "k8s.gcr.io/conformance"
 	// DefaultKubeConformanceImageTag is the default tag of the conformance image
 	DefaultKubeConformanceImageTag = "latest"
 	// DefaultAggregationServerBindPort is the default port for the aggregation server to bind to.

--- a/site/docs/master/airgap.md
+++ b/site/docs/master/airgap.md
@@ -40,8 +40,8 @@ To ensure you use the correct version of the conformance image, check your serve
 PRIVATE_REG=<private registry>
 CLUSTER_VERSION=<version of k8s you are targeting; e.g. v1.16.0>
 
-docker pull gcr.io/google-containers/conformance:$CLUSTER_VERSION
-docker tag gcr.io/google-containers/conformance:$CLUSTER_VERSION $PRIVATE_REG/conformance:$CLUSTER_VERSION
+docker pull k8s.gcr.io/conformance:$CLUSTER_VERSION
+docker tag k8s.gcr.io/conformance:$CLUSTER_VERSION $PRIVATE_REG/conformance:$CLUSTER_VERSION
 docker push $PRIVATE_REG/conformance:$CLUSTER_VERSION
 ```
 

--- a/site/docs/master/faq.md
+++ b/site/docs/master/faq.md
@@ -44,7 +44,7 @@ For example: Did any of the nodes have memory pressure? Did the scheduler pod go
 As a final resort, you can also read the upstream test code to determine what actions were being performed at the point when the test failed.
 If you decide to take this approach, you must ensure that you are reading the version of the test code that corresponds to your test image.
 You can verify which version of the test image was used by inspecting the plugin definition which is available in the results tarball in `plugins/e2e/definition.json` under the key `Definition.spec.image`.
-For example, if the test image was `gcr.io/google-containers/conformance:v1.15.3`, you should read the code at the corresponding [v1.15.3 tag in GitHub][kubernetes-1.15.3].
+For example, if the test image was `k8s.gcr.io/conformance:v1.15.3`, you should read the code at the corresponding [v1.15.3 tag in GitHub][kubernetes-1.15.3].
 All the tests can be found within the `test/e2e` directory in the Kubernetes repository.
 
 ### How can I run the E2E tests with certain test framework options set? What are the available options?
@@ -54,7 +54,7 @@ To view the available options that you can set when running the tests, you can r
 
 ```
 KUBE_VERSION=<Kubernetes version you are using>
-docker run -it gcr.io/google-containers/conformance:$KUBE_VERSION ./e2e.test --help
+docker run -it k8s.gcr.io/conformance:$KUBE_VERSION ./e2e.test --help
 ```
 
 You can also view the definitions of these test framework flags in the [Kubernetes repository][framework-flags].


### PR DESCRIPTION
**What this PR does / why we need it**:
Sonobuoy was using `gcr.io/google-containers` as the registry to fetch
the conformance from. `k8s.gcr.io` used to point to this registry
however is now being switched to point to a community controlled
repository: `{asia,eu,us}.gcr.io/k8s-artifacts-prod`.

The repository `gcr.io/google-containers` is now entering a read-only
state and should not be used. Instead, we should use the vanity domain
`k8s.gcr.io`.

The previously used `google-containers` registry is still available for
old image versions so should not affect previous releases of Sonobuoy
that reference it explicitly. Those versions of Sonobuoy would only be
used with older Kubernetes versions where the corresponding conformance
image version will still exist in that registry.

Reference:
- https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md
- https://groups.google.com/g/kubernetes-sig-release/c/lFmJZKwIxyI/m/tY6cv5uIAwAJ

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Special notes for your reviewer**:

**Release note**:
```
Sonobuoy now uses `k8s.gcr.io` as the registry to pull the conformance image from as `gcr.io/google-containers` is no longer being used and is now read-only. Older versions of Sonobuoy which are being used to test older versions of Kubernetes will continue to work as the conformance images for those older Kubernetes versions will still be accessible from `gcr.io/google-containers`.
```
