### PR TITLE
Update gem kramdown for site generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 .DS_Store
 .vscode
+.idea
 
 # we output results to this directory by default
 /archive

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (>= 2.3.0)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)


### PR DESCRIPTION
This update is to address CVE-2020-14001
https://github.com/advisories/GHSA-mqm2-cgpr-p4m6

The kramdown gem before 2.3.0 for Ruby processes the template option inside
Kramdown documents by default, which allows unintended read access
(such as template="/etc/passwd") or unintended embedded Ruby code execution
(such as a string that begins with template="string://<%= `).

NOTE: kramdown is used in Jekyll, GitLab Pages, GitHub Pages, and Thredded Forum.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
