### PR TITLE
Adding cluster inventory plugin documentation

### DIFF
--- a/site/_plugin-list/06-cluster-inventory.md
+++ b/site/_plugin-list/06-cluster-inventory.md
@@ -1,0 +1,5 @@
+---
+title: Cluster-Inventory
+link: https://github.com/vmware-tanzu/sonobuoy-plugins/tree/master/cluster-inventory
+---
+This plugin allows the collection of cluster information, such as workload and operational details, across all namespaces.


### PR DESCRIPTION
This PR updates the plugin documentation to include the newly added cluster inventory plugin found here https://github.com/vmware-tanzu/sonobuoy-plugins/tree/master/cluster-inventory