### PR TITLE
Deterministic TagPair assertion of custom registry

### DIFF
--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -254,7 +254,7 @@ func GetE2EImages(e2eRegistryConfig, version string) ([]string, error) {
 	return imageNames, nil
 }
 
-// GetE2EImagePairs gets a list of E2E image tag pairs from the default src to custom destination
+// GetE2EImageTagPairs gets a list of E2E image tag pairs from the default src to custom destination
 func GetE2EImageTagPairs(e2eRegistryConfig, version string) ([]TagPair, error) {
 	defaultImageRegistry, err := NewRegistryList("", version)
 	if err != nil {

--- a/pkg/image/manifest_test.go
+++ b/pkg/image/manifest_test.go
@@ -164,21 +164,28 @@ func TestGetE2EImageTagPairs(t *testing.T) {
 	}
 	expectedDefaultRegistry := defaultRegistry.v1_17()
 	if len(imageTagPairs) != len(expectedDefaultRegistry) {
-		t.Fatalf("Unexpected number of image tag pairs returned, expected %v, got %v", len(expectedDefaultRegistry), len(imageTagPairs))
+		t.Fatalf("unexpected number of image tag pairs returned, expected %v, got %v", len(expectedDefaultRegistry), len(imageTagPairs))
 	}
 
-	// Check one of the returned image pairs to ensure correct format
-	imageTagPair := imageTagPairs[0]
-	if strings.HasPrefix(imageTagPair.Src, customRegistry) {
-		t.Errorf("Src image should not have custom registry prefix: %q", imageTagPair.Src)
+	// As a sample, check one of the images for E2E and assert their mapping
+	var e2eImageTagPair TagPair
+	for _, imageTagPair := range imageTagPairs {
+		if strings.Contains(imageTagPair.Src, "e2e") {
+			e2eImageTagPair = imageTagPair
+			break
+		}
 	}
 
-	imageComponents := strings.SplitAfter(imageTagPair.Src, "/")
-	if !strings.HasPrefix(imageTagPair.Dst, customRegistry) {
-		t.Errorf("Expected Dst image to have prefix %q, got %q", customRegistry, imageTagPair.Dst)
+	if strings.HasPrefix(e2eImageTagPair.Src, customRegistry) {
+		t.Errorf("src image should not have custom registry prefix: %q", e2eImageTagPair.Src)
 	}
-	if !strings.HasSuffix(imageTagPair.Dst, imageComponents[len(imageComponents)-1]) {
-		t.Errorf("Expected Dst image to have suffix %q, got %q", imageComponents[len(imageComponents)-1], imageTagPair.Dst)
+
+	imageComponents := strings.SplitAfter(e2eImageTagPair.Src, "/")
+	if !strings.HasPrefix(e2eImageTagPair.Dst, customRegistry) {
+		t.Errorf("expected Dst image to have prefix %q, got %q", customRegistry, e2eImageTagPair.Dst)
+	}
+	if !strings.HasSuffix(e2eImageTagPair.Dst, imageComponents[len(imageComponents)-1]) {
+		t.Errorf("expected Dst image to have suffix %q, got %q", imageComponents[len(imageComponents)-1], e2eImageTagPair.Dst)
 	}
 }
 

--- a/pkg/image/manifest_test.go
+++ b/pkg/image/manifest_test.go
@@ -176,6 +176,9 @@ func TestGetE2EImageTagPairs(t *testing.T) {
 		}
 	}
 
+	if e2eImageTagPair == (TagPair{}) {
+		t.Errorf("no e2eImageTagPair is found")
+	}
 	if strings.HasPrefix(e2eImageTagPair.Src, customRegistry) {
 		t.Errorf("src image should not have custom registry prefix: %q", e2eImageTagPair.Src)
 	}


### PR DESCRIPTION
This ensures that we are testing images which were overriden by custom
registry. Some registries are meant to be excluded from override.

See #1181 for details.

Signed-off-by: Wilson E. Husin <whusin@vmware.com>


**What this PR does / why we need it**:
Stabilizes unit tests flake

**Which issue(s) this PR fixes**
- Fixes #1181

**Special notes for your reviewer**:
-

**Release note**:
```
NONE
```
