### PR TITLE
Use mirror.gcr.io by default

### DIFF
--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -118,7 +118,7 @@ const (
 const (
 	buildImageRegistry      = "k8s.gcr.io/build-image"
 	dockerGluster           = "docker.io/gluster"
-	dockerLibraryRegistry   = "docker.io/library"
+	dockerLibraryRegistry   = "mirror.gcr.io/library"
 	e2eRegistry             = "gcr.io/kubernetes-e2e-test-images"
 	e2eVolumeRegistry       = "gcr.io/kubernetes-e2e-test-images/volume"
 	etcdRegistry            = "quay.io/coreos"


### PR DESCRIPTION
**What this PR does / why we need it**:
While still rate-limited, GCR's mirror of Docker Hub has a significantly higher threshold (assuming the same rate limit for any GCR repository)

Reference: https://cloud.google.com/container-registry/quotas

**Which issue(s) this PR fixes**
None

**Special notes for your reviewer**:
None

**Release note**:
```
dockerLibraryRegistry default entry is now mirror.gcr.io
```
