### PR TITLE
Use "stale" label for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ exemptLabels:
   - security
   - wip
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   There has not been much activity here.


### PR DESCRIPTION
**What this PR does / why we need it**:

"wontfix" seems to imply more than "no activity", when we actually are
okay with reopening previously closed issues with no resolution

**Which issue(s) this PR fixes**
None

**Special notes for your reviewer**:
None

**Release note**:
```
None
```
