### PR TITLE
Circle CI tests migration to GitHub Actions

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -13,3 +13,19 @@ jobs:
           VERBOSE: true
         run: |
           make local-test
+  stress-test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: make stress-test
+        env:
+          VERBOSE: true
+        run: |
+          make stress
+  integration-test-on-kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: run tests
+        run: |
+          SONOBUOY_CLI=../../build/linux/amd64/sonobuoy ./scripts/run_integration_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER John Schnake "jschnake@vmware.com"
 
 CMD1
 

--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER John Schnake "jschnake@vmware.com"
 
 ADD BINARY /sonobuoy.exe
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ pre:
 	 chmod +x ./manifest-tool
 	echo $(DOCKERHUB_TOKEN) | docker login --username sonobuoybot --password-stdin
 
+# TODO: Make it easy to build single container for a specific arch
 build_container:
 	$(DOCKER) build \
        -t $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) \

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -9,7 +9,7 @@ cluster="kind"
 testImage="sonobuoy/testimage:v0.1"
 
 if ! kind get clusters | grep -q "^$cluster$"; then
-    kind create cluster --name $cluster
+    kind create cluster --name $cluster --config $DIR/kind-config.yaml
     # Although the cluster has been created, not all the pods in kube-system are created/available
     sleep 20
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Moving off Circle CI to have less service dependencies. End user / product should not be impacted.

**Which issue(s) this PR fixes**
Partially #1178

**Special notes for your reviewer**:
- [x] unit test (#1186)
- [x] stress test
- [x] integration test
- [ ] release pipeline (will tackle on a separate PR since we probably want to have some sort of canary for the next few releases)

**Release note**:
```
NONE
```
