### PR TITLE
Use distroless images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ CMD1
 
 ADD BINARY /sonobuoy
 WORKDIR /
-CMD /sonobuoy aggregator --no-exit -v 3 --logtostderr
+CMD ["/sonobuoy", "aggregator", "--no-exit", "-v", "3", "--logtostderr"]

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ WIN_IMAGE ?= mcr.microsoft.com/windows/servercore:1809
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 COVERARGS ?= -coverprofile=coverage.txt -covermode=atomic
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
-TEST_CMD = go test $(TESTARGS)
-TEST = GODEBUG=x509ignoreCN=0 $(TEST_CMD) $(COVERARGS) $(TEST_PKGS)
+TEST_CMD = GODEBUG=x509ignoreCN=0 go test $(TESTARGS)
+TEST = $(TEST_CMD) $(COVERARGS) $(TEST_PKGS)
 
 INT_TEST_PKGS ?= $(GOTARGET)/test/integration/...
 INT_TEST= $(TEST_CMD) $(INT_TEST_PKGS) -tags=integration

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= golang:1.15-buster
-AMD_IMAGE ?= debian:buster-slim
+AMD_IMAGE ?= gcr.io/distroless/static-debian10:latest
 ARM_IMAGE ?= arm64v8/ubuntu:16.04
 WIN_IMAGE ?= mcr.microsoft.com/windows/servercore:1809
 

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -57,6 +57,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdRun())
 	cmds.AddCommand(NewCmdImages())
 	cmds.AddCommand(NewCmdResults())
+	cmds.AddCommand(NewCmdSplat())
 
 	klog.InitFlags(nil)
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)

--- a/cmd/sonobuoy/app/splat.go
+++ b/cmd/sonobuoy/app/splat.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 VMware Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSplat() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "splat AGGREGATOR_RESULTS_PATH",
+		Short: "Reads all tarballs in the specified directory and prints the content to STDOUT (for internal use)",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runSplat(args[0]); err != nil {
+				errlog.LogError(err)
+				os.Exit(1)
+			}
+		},
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+	}
+	return cmd
+}
+
+func runSplat(dirPath string) error {
+	sonobuoyResults, err := filepath.Glob(filepath.Join(dirPath, "*.tar.gz"))
+	if err != nil {
+		return err
+	}
+
+	if err = loadResults(os.Stdout, sonobuoyResults); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadResults(w *os.File, filenames []string) error {
+	gzipWriter := gzip.NewWriter(w)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	for _, filename := range filenames {
+		if err := addFileToTarball(tarWriter, filename); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addFileToTarball(tarWriter *tar.Writer, filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	infoHeader, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// archive path of content as basename instead of full path
+	// so un-archiving will result in the working directory, not AGGREGATOR_RESULTS_PATH
+	header, err := tar.FileInfoHeader(infoHeader, infoHeader.Name())
+	if err != nil {
+		return err
+	}
+
+	if err = tarWriter.WriteHeader(header); err != nil {
+		return err
+	}
+
+	fileContent, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tarWriter.Write(fileContent); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -22,9 +22,10 @@ RUN go mod download
 
 # Get the rest of the files and build.
 COPY src .
-RUN go build -o /go/bin/testImage ./...
+RUN CGO_ENABLED=0 go build -o /go/bin/testImage ./...
 
-FROM gcr.io/distroless/static-debian10
+FROM gcr.io/distroless/static-debian10:latest
+WORKDIR /
 COPY --from=base /go/bin/testImage /testImage
 COPY resources /resources
 CMD [ "/testImage" ]

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14-stretch AS base
+FROM golang:1.15-buster AS base
 WORKDIR /src
 
 # Handle the go modules first to take advantage of Docker cache.
@@ -24,8 +24,7 @@ RUN go mod download
 COPY src .
 RUN go build -o /go/bin/testImage ./...
 
-FROM debian:stretch-slim
-MAINTAINER John Schnake "jschnake@vmware.com"
-COPY --from=base /go/bin/testImage /bin/testImage
+FROM gcr.io/distroless/static-debian10
+COPY --from=base /go/bin/testImage /testImage
 COPY resources /resources
-CMD [ "testImage" ]
+CMD [ "/testImage" ]

--- a/test/integration/testImage/yaml/ds-junit-passing-tar.yaml
+++ b/test/integration/testImage/yaml/ds-junit-passing-tar.yaml
@@ -8,7 +8,7 @@ spec:
   - /resources/hello-world.txt
   - /resources/junit-multi-suite-single-failure.xml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/ds-manual.yaml
+++ b/test/integration/testImage/yaml/ds-manual.yaml
@@ -11,7 +11,7 @@ spec:
   - /resources/manual-results-1.yaml
   - /resources/manual-results-2.yaml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/ds-raw-passing-tar.yaml
+++ b/test/integration/testImage/yaml/ds-raw-passing-tar.yaml
@@ -8,7 +8,7 @@ spec:
   - /resources/hello-world.txt
   - /resources/junit-multi-suite-single-failure.xml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/job-junit-passing-singlefile.yaml
+++ b/test/integration/testImage/yaml/job-junit-passing-singlefile.yaml
@@ -7,7 +7,7 @@ spec:
   - single-file
   - /resources/junit-passing-tests.xml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/job-manual.yaml
+++ b/test/integration/testImage/yaml/job-manual.yaml
@@ -11,7 +11,7 @@ spec:
   - /resources/manual-results-1.yaml
   - /resources/manual-results-2.yaml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/job-raw-singlefile.yaml
+++ b/test/integration/testImage/yaml/job-raw-singlefile.yaml
@@ -7,7 +7,7 @@ spec:
   - single-file
   - /resources/hello-world.txt
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}

--- a/test/integration/testImage/yaml/manual-with-arbitrary-details.yaml
+++ b/test/integration/testImage/yaml/manual-with-arbitrary-details.yaml
@@ -9,7 +9,7 @@ spec:
   - single-file
   - /resources/manual-results-with-arbitrary-details.yaml
   command:
-  - testImage
+  - /testImage
   image: sonobuoy/testimage:v0.1
   name: plugin
   resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use distroless container image for smaller size of deployment and less maintenance on potentially vulnerable programs which we do not use but included in Debian base container.

**Blockers**:
 #1206

**Which issue(s) this PR fixes**
N/A

**Special notes for your reviewer**:
- [x] amd64
- [ ] arm64

**Release note**:
```
Sonobuoy aggregator pod is now built based on Distroless container
```
