### PR TITLE
support mips64le architecture.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,13 @@ jobs:
       - checkout
       - run:
           name: "Build Sonobuoy binaries"
-          command: make build/linux/amd64/sonobuoy build/linux/arm64/sonobuoy
+          command: make build/linux/amd64/sonobuoy build/linux/arm64/sonobuoy build/linux/mips64le/sonobuoy
       - persist_to_workspace:
           root: ~/project
           paths: 
             - build/linux/amd64/*
             - build/linux/arm64/*
+            - build/linux/mips64le/* 
 
   build_containers:
     machine:
@@ -67,7 +68,7 @@ jobs:
       - run:
           name: Save as tar files to persist to next step
           command: |
-            docker save -o sonobuoyImages.tar.gz sonobuoy/sonobuoy sonobuoy/sonobuoy-amd64 sonobuoy/sonobuoy-arm64
+            docker save -o sonobuoyImages.tar.gz sonobuoy/sonobuoy sonobuoy/sonobuoy-amd64 sonobuoy/sonobuoy-arm64 sonobuoy/sonobuoy-mips64le
       - persist_to_workspace:
           root: /home/circleci/project
           paths:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     - amd64
     - arm64
     - 386
+    - mips64le  
   ignore:
     - goos: darwin
       goarch: 386

--- a/manifest_spec.yaml.tmpl
+++ b/manifest_spec.yaml.tmpl
@@ -10,6 +10,11 @@ manifests:
     platform:
       architecture: arm64
       os: linux
+  -
+    image: REGISTRY/sonobuoy-mips64le:TAG
+    platform:
+      architecture: mips64le
+      os: linux
 WIN_ONLY  -
 WIN_ONLY    image: REGISTRY/sonobuoy-win-amd64:TAG
 WIN_ONLY    platform:


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been verified that sonobuoy can be used normally on the mips64le platform, in order to facilitate the use of it on more architecture platforms, so submit.

**Which issue(s) this PR fixes**
- Fixes #
support more cpu architecture

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
Signed-off-by: houfangdong <houfangdong@loongson.com>
