### PR TITLE
Bump sonobuoy version

### DIFF
--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -20,7 +20,7 @@ limitations under the License.
 package buildinfo
 
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
-var Version = "v0.20.0"
+var Version = "v0.50.0"
 
 // GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
 var GitSHA string


### PR DESCRIPTION
The executable on github is correctly reporting v0.50.0 but not
master. So developer builds are incorrectly showing v0.20.0.

Signed-off-by: John Schnake <jschnake@vmware.com>