### PR TITLE
fix e2e plugin reference 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ See [the list of releases][releases] to find out about feature changes.
 [contrib]: https://github.com/vmware-tanzu/sonobuoy/blob/master/CONTRIBUTING.md
 [docker]: https://docs.docker.com/get-docker/
 [docs]: https://sonobuoy.io/docs
-[e2ePlugin]: https://sonobuoy.io/docs/e2eplugin
+[e2ePlugin]: https://sonobuoy.io/docs/master/e2eplugin/
 [customPlugins]: https://sonobuoy.io/docs/plugins
 [gen]: https://sonobuoy.io/docs/gen
 [issue]: https://github.com/vmware-tanzu/sonobuoy/issues


### PR DESCRIPTION
- fix e2e plugin reference


**What this PR does / why we need it**:
fix typo for the primary README.md in the repo 

**Which issue(s) this PR fixes**
- Fixes  #1232

**Special notes for your reviewer**:
just fixed the URL to reference the master branch, shouldn't it be migrated to **main**
**Release note**:
```
release-note
```
