### PR TITLE
Add support for testing against the most recent dev E2E image

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -113,6 +113,7 @@ func AddSystemdLogsImage(image *string, flags *pflag.FlagSet) {
 func AddKubeConformanceImageVersion(imageVersion *image.ConformanceImageVersion, flags *pflag.FlagSet) {
 	help := "Use default Conformance image, but override the version. "
 	help += "Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise."
+	help += "You can also choose 'latest' which will find the latest dev image upstream."
 
 	*imageVersion = image.ConformanceImageVersionAuto
 	flags.Var(imageVersion, "kube-conformance-image-version", help)

--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -34,60 +34,6 @@ const (
 	rawInput = "not nil"
 )
 
-// TestResolveConformanceImage tests the temporary logic of ensuring that given
-// a certain string version, the proper conformance image is used (upstream
-// vs Heptio).
-func TestResolveConformanceImage(t *testing.T) {
-	tcs := []struct {
-		name             string
-		requestedVersion string
-		expected         string
-	}{
-		{
-			name:             "Comparison is lexical",
-			requestedVersion: "foo",
-			expected:         "gcr.io/heptio-images/kube-conformance:foo",
-		}, {
-			name:             "Prior to v1.14.0 uses heptio and major.minor",
-			requestedVersion: "v1.13.99",
-			expected:         "gcr.io/heptio-images/kube-conformance:v1.13.99",
-		}, {
-			name:             "v1.14.0 uses heptio and major.minor",
-			requestedVersion: "v1.14.0",
-			expected:         "gcr.io/heptio-images/kube-conformance:v1.14.0",
-		}, {
-			name:             "v1.14.1 and after uses upstream and major.minor.patch",
-			requestedVersion: "v1.14.1",
-			expected:         "k8s.gcr.io/conformance:v1.14.1",
-		}, {
-			name:             "v1.14.0 and after uses upstream and major.minor.patch",
-			requestedVersion: "v1.15.1",
-			expected:         "k8s.gcr.io/conformance:v1.15.1",
-		}, {
-			name:             "latest should use upstream image",
-			requestedVersion: "latest",
-			expected:         "k8s.gcr.io/conformance:latest",
-		}, {
-			name:             "explicit version before v1.14.0 should use heptio image and given version",
-			requestedVersion: "v1.12+.0.alpha+",
-			expected:         "gcr.io/heptio-images/kube-conformance:v1.12+.0.alpha+",
-		}, {
-			name:             "explicit version after v1.14.0 should use upstream and use given version",
-			requestedVersion: "v1.14.1",
-			expected:         "k8s.gcr.io/conformance:v1.14.1",
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			out := resolveConformanceImage(tc.requestedVersion)
-			if out != tc.expected {
-				t.Errorf("Expected image %q but got %q", tc.expected, out)
-			}
-		})
-	}
-}
-
 func TestResolveConfig(t *testing.T) {
 	defaultPluginSearchPath := config.New().PluginSearchPath
 	defaultAggr := plugin.AggregationConfig{TimeoutSeconds: 10800}

--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -407,7 +407,7 @@ func collectPluginsImages(plugins []string, k8sVersion string, client image.Clie
 		case systemdLogsPlugin:
 			images = append(images, config.DefaultSystemdLogsImage)
 		case e2ePlugin:
-			conformanceImage := resolveConformanceImage(k8sVersion)
+			conformanceImage := fmt.Sprintf("%v:%v", config.UpstreamKubeConformanceImageURL, k8sVersion)
 			images = append(images, conformanceImage)
 			logrus.Info("conformance image to be used: ", conformanceImage)
 


### PR DESCRIPTION
Special handling to identify the E2E image most recently pushed
for dev builds. Very helpful if you are developing recent features
or demoing them. Specify the --kube-conformance-image-version=latest
to get this behavior.

Fixes #1231

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Test against the master branch of k8s by specifying the --kube-conformance-image-version=latest.
```
