### PR TITLE
Add a checkout step that was missed

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -38,7 +38,7 @@ jobs:
             sonobuoyImages.tar
   stress-test-linux:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@v2
       - name: Run stress tests
         env:
@@ -49,10 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, unit-test-linux]
     steps:
-      - uses: actions/checkout@v2  
+      - uses: actions/checkout@v2
       - name: Prepare cluster for tests
         run: |
-          source ./scripts/build.sh; 
+          source ./scripts/build.sh;
           clean
           setup_kind_cluster
       - name: Download binaries and prebuilt images
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, unit-test-linux, integration-test-on-kind, stress-test-linux]
     steps:
+      - uses: actions/checkout@v2
       - name: Download binaries and prebuilt images
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
When pushing images you still need to checkout the
repo to get the script that does the pushing.

Signed-off-by: John Schnake <jschnake@vmware.com>

https://github.com/vmware-tanzu/sonobuoy/runs/2512840029?check_suite_focus=true

From the last PR reported it didnt have the build script. I had split out the push vs release after I had validated the other code so I didnt catch this.