### PR TITLE
Don't use x509 common names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ WIN_IMAGE ?= mcr.microsoft.com/windows/servercore:1809
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 COVERARGS ?= -coverprofile=coverage.txt -covermode=atomic
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
-TEST_CMD = GODEBUG=x509ignoreCN=0 go test $(TESTARGS)
+TEST_CMD = go test $(TESTARGS)
 TEST = $(TEST_CMD) $(COVERARGS) $(TEST_PKGS)
 
 INT_TEST_PKGS ?= $(GOTARGET)/test/integration/...

--- a/pkg/backplane/ca/ca.go
+++ b/pkg/backplane/ca/ca.go
@@ -71,7 +71,7 @@ func NewAuthority() (*Authority, error) {
 	cert, err := auth.makeCert(privKey.Public(), func(cert *x509.Certificate) {
 		cert.IsCA = true
 		cert.KeyUsage = x509.KeyUsageCertSign
-		cert.Subject.CommonName = caName
+		cert.DNSNames = []string{caName}
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't create certificate authority root certificate")
@@ -82,7 +82,6 @@ func NewAuthority() (*Authority, error) {
 
 // makeCert takes a public key and a function to mutate the certificate template with updated parameters
 func (a *Authority) makeCert(pub crypto.PublicKey, mut func(*x509.Certificate)) (*x509.Certificate, error) {
-
 	serialNumber := a.nextSerial()
 	validFrom := time.Now()
 	tmpl := x509.Certificate{
@@ -189,7 +188,7 @@ func (a *Authority) MakeServerConfig(name string) (*tls.Config, error) {
 func (a *Authority) ClientKeyPair(name string) (*tls.Certificate, error) {
 	cert, err := a.makeLeafCert(func(cert *x509.Certificate) {
 		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
-		cert.Subject.CommonName = name
+		cert.DNSNames = []string{name}
 	})
 	return cert, errors.Wrap(err, "couldn't make client certificate")
 }

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -34,17 +34,17 @@ WIN_IMAGE=mcr.microsoft.com/windows/servercore:1809
 TEST_IMAGE=testimage:v0.1
 
 unit_local() {
-	GODEBUG=x509ignoreCN=0 go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/...
+	go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/...
 }
 
 unit() {
 	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
-    "GODEBUG=x509ignoreCN=0 go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/..."
+    "go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/..."
 }
 
 stress() {
 	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
-    "GODEBUG=x509ignoreCN=0 go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/test/stress/..."
+    "go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/test/stress/..."
 }
 
 integration() {
@@ -56,7 +56,6 @@ integration() {
         -w "$BUILDMNT" \
         --env ARTIFACTS_DIR=/tmp/artifacts \
         --env SONOBUOY_CLI="$SONOBUOY_CLI" \
-        --env GODEBUG=x509ignoreCN=0 \
         --network host \
         "$BUILD_IMAGE" \
     go test ${VERBOSE:+-v} -timeout 3m -tags=integration "$GOTARGET"/test/integration/...


### PR DESCRIPTION
Use Subject Alternate Names fields instead.

Fixes: #1227

Signed-off-by: John Schnake <jschnake@vmware.com>