### PR TITLE
Fix link

### DIFF
--- a/site/content/plugins/_index.md
+++ b/site/content/plugins/_index.md
@@ -9,4 +9,4 @@ Sonobuoy was always designed to facilitate third-party plugins in order to accom
 
 Read more about the first Sonobuoy plugins [here][1].
 
-[1]: http://127.0.0.1:4000/cis-benchmark-plugin/
+[1]: https://sonobuoy.io/cis-benchmark-plugin/


### PR DESCRIPTION
The Hugo overhaul changed so much it was just spot checked
I assume. For some reason it replaced this link badly so
this just resets the value for this particular link.

Will fix others as we find them.

Fixes #1238

Signed-off-by: John Schnake <jschnake@vmware.com>