### PR TITLE
Fix doc redirects

### DIFF
--- a/site/themes/sonobuoy/layouts/index.redirects
+++ b/site/themes/sonobuoy/layouts/index.redirects
@@ -2,3 +2,4 @@
 /docs                          /docs/{{ $latest }}     301!
 /docs/latest                   /docs/{{ $latest }}
 /docs/latest/*                 /docs/{{ $latest }}/:splat
+/docs/*                        /docs/{{ $latest }}/:splat


### PR DESCRIPTION
Adds a new set of redirects so links like "docs/foo" go to
"docs/vLatest/foo".

Fixes #1232

Signed-off-by: John Schnake <jschnake@vmware.com>