### PR TITLE
Windows builds in CI

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -17,11 +17,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       - name: Build binaries and images
         run: |
           source ./scripts/build.sh
           build_binaries
           linux_containers
+          windows_containers
           build_test_image
       - name: Save images to tar
         run: |
@@ -30,12 +49,9 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: sonobuoy-binaries-images-${{ github.run_id }}
+          name: sonobuoy-build-${{ github.run_id }}
           path: |
-            build/linux/amd64/sonobuoy
-            build/linux/arm64/sonobuoy
-            build/windows/amd64/sonobuoy.exe
-            sonobuoyImages.tar
+            build
   stress-test-linux:
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +74,8 @@ jobs:
       - name: Download binaries and prebuilt images
         uses: actions/download-artifact@v2
         with:
-          name: sonobuoy-binaries-images-${{ github.run_id }}
+          name: sonobuoy-build-${{ github.run_id }}
+          path: build
       - name: Ensure binaries are executable
         run: |
           chmod +x build/linux/amd64/sonobuoy
@@ -69,9 +86,11 @@ jobs:
           find ./build
       - name: Build test image, load images, and run tests
         run: |
-          source ./scripts/build.sh
-          load_images_from_tar_into_cluster sonobuoyImages.tar
+          docker load -i build/testimage-${{ github.run_id }}.tar
+          docker load -i build/linux/amd64/sonobuoy-img-linux-amd64-${{ github.run_id }}.tar
           docker image ls
+          source ./scripts/build.sh
+          load_test_images_into_cluster
           VERBOSE=true SONOBUOY_CLI=../../build/linux/amd64/sonobuoy integration
   push-images:
     if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
@@ -82,17 +101,24 @@ jobs:
       - name: Download binaries and prebuilt images
         uses: actions/download-artifact@v2
         with:
-          name: sonobuoy-binaries-images-${{ github.run_id }}
+          name: sonobuoy-build-${{ github.run_id }}
+          path: build
+          # TODO: Load only what is needed
       - name: Load images and verify
         run: |
-          docker load -i sonobuoyImages.tar
-          docker images
+          docker load -i build/testimage.tar
+          docker load -i build/linux/amd64/sonobuoy-img-linux-amd64-${{ github.run_id }}.tar
+          docker load -i build/linux/arm64/sonobuoy-img-linux-arm64-${{ github.run_id }}.tar
+          docker image ls
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push images
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ./scripts/build.sh
           gen_manifest_and_push_all

--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+ARG BASEIMAGE
+FROM ${BASEIMAGE}
 
-ADD BINARY /sonobuoy.exe
+ADD build/windows/amd64/sonobuoy.exe /sonobuoy.exe
 WORKDIR /
 CMD /sonobuoy.exe aggregator --no-exit -v 3 --logtostderr

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -10,8 +10,10 @@ GOTARGET=github.com/vmware-tanzu/"$TARGET"
 GOPATH=$(go env GOPATH)
 REGISTRY=sonobuoy
 LINUX_ARCH=(amd64 arm64)
+
+# Currently only under a single arch, can iterate over these and still assume arch value.
 WIN_ARCH=amd64
-KIND_CLUSTER=kind
+WINVERSIONS=("1809" "1903" "1909" "2004" "20H2")
 
 # Not used for pushing images, just for local building on other GOOS. Defaults to
 # grabbing from the local go env but can be set manually to avoid that requirement.
@@ -23,32 +25,32 @@ GIT_VERSION=$(git describe --always --dirty --tags)
 IMAGE_VERSION=$(git describe --always --dirty --tags)
 IMAGE_TAG=$(echo "$IMAGE_VERSION" | cut -d. -f1,2)
 IMAGE_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\///g')
-GIT_REF_SHORT=$(git rev-parse --short=8 --verify HEAD)
 GIT_REF_LONG=$(git rev-parse --verify HEAD)
 
 BUILDMNT=/go/src/$GOTARGET
 BUILD_IMAGE=golang:1.16
 AMD_IMAGE=gcr.io/distroless/static:nonroot
 ARM_IMAGE=gcr.io/distroless/static:nonroot-arm64
-WIN_IMAGE=mcr.microsoft.com/windows/servercore:1809
+WIN_AMD64_BASEIMAGE=mcr.microsoft.com/windows/nanoserver
 TEST_IMAGE=testimage:v0.1
+KIND_CLUSTER=kind
 
 unit_local() {
-	go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/...
+    go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/...
 }
 
 unit() {
-	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
+    docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
     "go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/cmd/... $GOTARGET/pkg/..."
 }
 
 stress() {
-	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
+    docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
     "go test ${VERBOSE:+-v} -timeout 60s -coverprofile=coverage.txt -covermode=atomic $GOTARGET/test/stress/..."
 }
 
 integration() {
-	docker run --rm \
+    docker run --rm \
         -v "$(pwd)":$BUILDMNT \
         -v /tmp/artifacts:/tmp/artifacts \
         -v "${HOME}"/.kube/config:/root/.kube/kubeconfig \
@@ -62,49 +64,60 @@ integration() {
 }
 
 lint() {
-	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
+    docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
     "golint -set_exit_status ${VERBOSE:+-v} -timeout 60s $GOTARGET/cmd/... $GOTARGET/pkg/..."
 }
 
 vet() {
-	docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
+    docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $BUILD_IMAGE /bin/sh -c \
     "CGO_ENABLED=0 go vet ${VERBOSE:+-v} -timeout 60s $GOTARGET/cmd/... $GOTARGET/pkg/..."
 }
 
 # Builds a container given the dockerfile and image name (not registry).
 # Dockerfiles typically generated via another method.
-build_container_dockerfile_image() {
+build_container_dockerfile_arch() {
 	docker build \
-        -t "$REGISTRY/$2:$IMAGE_VERSION" \
-        -t "$REGISTRY/$2:$IMAGE_TAG" \
-        -t "$REGISTRY/$2:$IMAGE_BRANCH" \
-        -t "$REGISTRY/$2:$GIT_REF_SHORT" \
+        -t "$REGISTRY/$TARGET:$2-$IMAGE_VERSION" \
+        -t "$REGISTRY/$TARGET:$2-$IMAGE_TAG" \
+        -t "$REGISTRY/$TARGET:$2-$IMAGE_BRANCH" \
         -f "$1" \
-		.
+        .
+}
+
+buildx_container_windows_version(){
+    BASEIMAGE="$WIN_AMD64_BASEIMAGE:$1"
+    mkdir -p "build/windows/$WIN_ARCH/$VERSION"
+    docker buildx build --pull \
+        --output=type=oci,dest=build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar \
+        --platform windows/amd64 \
+        -t $REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_VERSION \
+        --build-arg BASEIMAGE=$BASEIMAGE \
+        -f build/windows/$WIN_ARCH/Dockerfile \
+        .
 }
 
 # Generates a dockerfile given the os and arch (the 2 and only arguments).
 gen_dockerfile_for_os_arch(){
+    dockerfile="build/$1/$2/Dockerfile"
     if [ "$1" = "linux" ]; then
         if [ "$2" = "amd64" ]; then
             sed -e "s|BASEIMAGE|$AMD_IMAGE|g" \
                 -e 's|CMD1||g' \
-                -e 's|BINARY|build/linux/amd64/sonobuoy|g' Dockerfile > "Dockerfile-$arch"
+                -e 's|BINARY|build/linux/amd64/sonobuoy|g' Dockerfile > "$dockerfile"
         elif [ "$2" = "arm64" ]; then
             sed -e "s|BASEIMAGE|$ARM_IMAGE|g" \
                 -e 's|CMD1||g' \
-                -e 's|BINARY|build/linux/arm64/sonobuoy|g' Dockerfile > "Dockerfile-$arch"
+                -e 's|BINARY|build/linux/arm64/sonobuoy|g' Dockerfile > "$dockerfile"
         else
             echo "Linux ARCH unknown"
         fi
-    elif [ "$2" = "windows" ]; then
-        if [ "$arch" = "amd64" ]; then
-			sed -e "s|BASEIMAGE|$WIN_IMAGE|g" \
-			    -e 's|BINARY|build/windows/amd64/sonobuoy.exe|g' DockerfileWindows > "DockerfileWindows-$arch"
-			build_container_dockerfile_image "DockerfileWindows-$arch" sonobuoy
-			build_container_dockerfile_image "DockerfileWindows-$arch" "sonobuoy-win-$arch"
-		else 
-			echo "Windows ARCH unknown"
+    elif [ "$1" = "windows" ]; then
+        if [ "$2" = "amd64" ]; then
+            # Onlhy doing one arch so this could be hardcoded, likewise we could handle the
+            # base image differently. Wanted something here for parity with linux in case we expand it though.
+            sed -e 's|BINARY|build/windows/amd64/sonobuoy.exe|g' DockerfileWindows > "$dockerfile"
+        else 
+            echo "Windows ARCH unknown"
         fi
     else
         echo "OS unknown"
@@ -112,30 +125,33 @@ gen_dockerfile_for_os_arch(){
 }
 
 # Builds the image given just the os, arch, and image name.
-build_container_os_arch_image(){
+build_container_os_arch_version(){
+    dockerfile="build/$1/$2/Dockerfile"
     gen_dockerfile_for_os_arch "$1" "$2"
-    if [ "$1" = "windows" ]; then dockerfile=DockerfileWindows ; else dockerfile=Dockerfile ; fi
-    build_container_dockerfile_image "$dockerfile-$2" "$3"
+    if [ "$1" = "windows" ]; then 
+        buildx_container_windows_version $3
+    else
+        build_container_dockerfile_arch "$dockerfile" $2
+    fi
 }
 
 # Builds all linux images. Assumes binaries are available.
 linux_containers() {
-	for arch in "${LINUX_ARCH[@]}"; do
-        build_container_os_arch_image linux "$arch" sonobuoy-"$arch"
-        build_container_dockerfile_image Dockerfile-"$arch" sonobuoy-"$arch"
-	done
+    for arch in "${LINUX_ARCH[@]}"; do
+        build_container_os_arch_version linux "$arch"
+    done
 }
 
 # Builds the windows images. Assumes binary is available.
 windows_containers() {
-	for arch in "${WIN_ARCH[@]}"; do
-        build_container_dockerfile_image DockerfileWindows-"$arch" sonobuoy-win-"$arch"
-	done
+    for VERSION in "${WINVERSIONS[@]}"; do
+        build_container_os_arch_version windows "$WIN_ARCH" "$VERSION"
+    done
 }
 
 # Builds a binary for a specific goos/goarch.
 build_binary_GOOS_GOARCH() {
-	LDFLAGS="-s -w -X $GOTARGET/pkg/buildinfo.Version=$GIT_VERSION -X $GOTARGET/pkg/buildinfo.GitSHA=$GIT_REF_LONG"
+    LDFLAGS="-s -w -X $GOTARGET/pkg/buildinfo.Version=$GIT_VERSION -X $GOTARGET/pkg/buildinfo.GitSHA=$GIT_REF_LONG"
     args=(${VERBOSE:+-v} -ldflags "${LDFLAGS}" "$GOTARGET")
     if [ "$VERBOSE" ]; then args+=("-v"); fi;
 
@@ -174,31 +190,44 @@ native() {
 # Pushes sonobuoy images. Usually by branch/ref but by tag/latest if it is a new tag.
 push_images() {
     for arch in "${LINUX_ARCH[@]}"; do
-        docker push "$REGISTRY/$TARGET-$arch:$IMAGE_BRANCH"
-        docker push "$REGISTRY/$TARGET-$arch:$GIT_REF_SHORT"
+        docker push "$REGISTRY/$TARGET:$arch-$IMAGE_BRANCH"
+        docker push "$REGISTRY/$TARGET:$arch-$IMAGE_VERSION"
     done
-    # Currently not building windows images.
-    #for arch in "${WIN_ARCH[@]}"; do
-    #    docker push "$REGISTRY/$TARGET-win-$arch:$IMAGE_BRANCH"
-    #    docker push "$REGISTRY/$TARGET-win-$arch:$GIT_REF_SHORT"
-    #done
+    
+    export REGISTRY_AUTH_FILE=$(pwd)/auth.json
+    skopeo login --username $DOCKERHUB_USER --password $DOCKERHUB_TOKEN registry.hub.docker.com/$DOCKERHUB_USER
+    for VERSION in "${WINVERSIONS[@]}"; do
+        skopeo copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_BRANCH"
+        skopeo copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_VERSION"
+    done
 }
 
 # Generates the multi-os manifest for sonobuoy. First argument
 # is the tag for the manifest, 2nd is the image tags. 2nd value
-# defaults to GIT_REF_SHORT since that should always be pushed.
+# defaults to IMAGE_VERSION since that should always be pushed.
 gen_manifest_with_tag() {
-    imgTag="${2:-$GIT_REF_SHORT}"
-	docker manifest create \
-    "$REGISTRY/$TARGET:$1" \
-    --amend "$REGISTRY/$TARGET-amd64:$imgTag" \
-    --amend "$REGISTRY/$TARGET-arm64:$imgTag" 
+    imgTag="${2:-$IMAGE_VERSION}"
+
+    for arch in "${LINUX_ARCH[@]}"; do
+        docker manifest create \
+            "$REGISTRY/$TARGET:$1" \
+            --amend "$REGISTRY/$TARGET:$arch-$imgTag"
+    done
+    for VERSION in "${WINVERSIONS[@]}"; do
+        full_version=$(docker manifest inspect ${WIN_AMD64_BASEIMAGE}:${VERSION} | jq '.manifests[0].platform."os.version"' -r)
+        docker manifest create \
+            "$REGISTRY/$TARGET:$1" \
+            --amend "$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$imgTag"
+        docker manifest annotate "$REGISTRY/$TARGET:$1" \
+            "$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$imgTag" \
+            --os-version="${full_version}"
+    done
 }
 
 # Pushes the multi-os manifest for sonobuoy; must be generated first.
 push_manifest_with_tag() {
     gen_manifest_with_tag "$1"
-	docker manifest push "$REGISTRY/$TARGET:$1"
+    docker manifest push "$REGISTRY/$TARGET:$1"
 }
 
 # Pushes all images and the manifest.
@@ -206,25 +235,15 @@ push_manifest_with_tag() {
 # added as dependency due to having both Linux/Windows
 # prereqs which can't be done on the same machine.
 gen_manifest_and_push_all() {
-	# Pushes the images first
-    if [ "$PUSH_WINDOWS" ] ; then
-        for arch in "${WIN_ARCH[@]}"; do
-            push_images TARGET="sonobuoy-win-$arch"
-        done
-    else
-        echo 'PUSH_WINDOWS not set, not pushing Windows images'
-        for arch in "${LINUX_ARCH[@]}"; do
-            push_images TARGET="sonobuoy-$arch"
-        done
-    fi
+    push_images
 
-	if git describe --tags --exact-match >/dev/null 2>&1 ; then
-		push_manifest_with_tag "$IMAGE_VERSION"
-		push_manifest_with_tag latest
-		push_manifest_with_tag "$IMAGE_TAG"
-        push_manifest_with_tag "$GIT_REF_SHORT"
+    if git describe --tags --exact-match >/dev/null 2>&1 ; then
+        push_manifest_with_tag "$IMAGE_VERSION"
+        push_manifest_with_tag "$IMAGE_BRANCH"
+        push_manifest_with_tag "$IMAGE_TAG"
+        push_manifest_with_tag latest
     else
-        push_manifest_with_tag "$GIT_REF_SHORT"
+        push_manifest_with_tag "$IMAGE_VERSION"
         push_manifest_with_tag "$IMAGE_BRANCH"
 	fi
 }
@@ -232,7 +251,7 @@ gen_manifest_and_push_all() {
 # Removes a given image from docker. Image name (not registry) should be the first
 # and only argument.
 remove-image() {
-	docker rmi -f "$(docker images "$REGISTRY/$1" -a -q)" || true
+    docker rmi -f "$(docker images "$REGISTRY/$1" -a -q)" || true
 }
 
 # Removes temp files, built images, etc so the next build and repo are
@@ -240,17 +259,9 @@ remove-image() {
 clean() {
     # Best effort for clean; don't exit if failure.
     set +e
-	rm -f "$TARGET"
-	rm Dockerfile-*
-	rm DockerfileWindows-*
-	rm -rf build
+    rm -f "$TARGET"
+    rm -rf build
 
-	for arch in "${LINUX_ARCH[@]}"; do
-		remove-image "$TARGET-$arch"
-	done
-	for arch in "${WIN_ARCH[@]}"; do
-		remove-image "$TARGET-win-$arch"
-	done
     remove-image "$TARGET"
     set -e
 }
@@ -260,14 +271,14 @@ clean() {
 kind_images() {
     K8S_PATH="$GOPATH/src/github.com/kubernetes/kubernetes"
     KIND_K8S_TAG="$(cd "$K8S_PATH" && git describe)"
-	kind build node-image --kube-root="$K8S_PATH" --image "$REGISTRY/kind-node:$KIND_K8S_TAG"
+    kind build node-image --kube-root="$K8S_PATH" --image "$REGISTRY/kind-node:$KIND_K8S_TAG"
 }
 
 # push_kind_images will push the same image kind_images just built our registry.
 push_kind_images() {
     K8S_PATH="$GOPATH"/src/github.com/kubernetes/kubernetes
     KIND_K8S_TAG="$(cd "$K8S_PATH" && git describe)"
-	docker push "$REGISTRY/kind-node:$KIND_K8S_TAG"
+    docker push "$REGISTRY/kind-node:$KIND_K8S_TAG"
 }
 
 # check-kind-env will show you what will be built/tagged before doing so with kind_images
@@ -280,7 +291,7 @@ check-kind-env() {
         echo KIND_K8S_TAG is undefined
         exit 1
     fi
-	echo --kube-root="$K8S_PATH" tagging as --image "$REGISTRY/kind-node:$KIND_K8S_TAG"
+    echo --kube-root="$K8S_PATH" tagging as --image "$REGISTRY/kind-node:$KIND_K8S_TAG"
 }
 
 # Creates the kind cluster if it does not already exist.
@@ -302,22 +313,19 @@ build_test_image(){
 
 # Saves the images which we persist in CI and use for testing/publishing.
 save_images_to_tar(){
-    # testimage is always built for sonobuoy since it never gets really pushed anywhere.
-    docker save -o sonobuoyImages.tar "$REGISTRY/$TARGET-amd64" "$REGISTRY/$TARGET-arm64" sonobuoy/testimage
+    # Save linux images to tar; for loading into test cluster and into build by os/arch for artifacts.
+    docker save -o build/testimage-$GITHUB_RUN_ID.tar sonobuoy/testimage
+    for arch in "${LINUX_ARCH[@]}"; do
+        docker save -o build/linux/$arch/sonobuoy-img-linux-$arch-$GITHUB_RUN_ID.tar "$REGISTRY/$TARGET:$arch-$IMAGE_VERSION" "$REGISTRY/$TARGET:$arch-$IMAGE_BRANCH"
+    done
 }
 
-# Loads sonobuoy image and the testing image into the kind cluster. Generally use
-# the tar version instead.
-load_images_into_cluster(){
+# Loads sonobuoy image and the testing image into the kind cluster.
+load_test_images_into_cluster(){
+    # Retag in case we are in a fork; ignore error on our own registry though.
+    docker tag $REGISTRY/$TARGET:amd64-$IMAGE_VERSION sonobuoy/$TARGET:$IMAGE_VERSION || true
+
+    # Tests will look for the sonobuoy images by default, so hard-code those.
     kind load docker-image --name $KIND_CLUSTER sonobuoy/$TARGET:$IMAGE_VERSION
     kind load docker-image --name $KIND_CLUSTER sonobuoy/$TEST_IMAGE
-}
-
-# Loads the images from the tar file into the kind cluster for testing.
-load_images_from_tar_into_cluster(){
-    docker load -i $1
-    # Manifest doesn't get created until publishing, so just tag one locally for testing.
-    # Also tagging test image with sonobuoy repo in case the $REGISTRY is different for dev.
-    docker tag $REGISTRY/$TARGET-amd64:$IMAGE_VERSION sonobuoy/$TARGET:$IMAGE_VERSION
-    load_images_into_cluster
 }


### PR DESCRIPTION
Adds windows builds for a number of OS versions to our CI pipeline.

Utilizes buildx and skopeo to build the windows images on the linux
runner and move them to dockerhub, then uses docker manifest to
create the manifest as usual.

In a quick reversal of a previous commit, we actually HAVE to put
all the images as "sonobuoy" and have the different arch/os use
different tags instead of different image names. This has to do with
how the manifest command looks up images and prevents issues wsuch as
"manifest not found" even though it does (as a differently named image
from the others).

Fixes #732

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Windows images are now built and published alongside the Linux/amd64 and Linux/am64 versions.
```
