### PR TITLE
Removing unnecessary and incorrect load of testimage

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -106,7 +106,6 @@ jobs:
           # TODO: Load only what is needed
       - name: Load images and verify
         run: |
-          docker load -i build/testimage.tar
           docker load -i build/linux/amd64/sonobuoy-img-linux-amd64-${{ github.run_id }}.tar
           docker load -i build/linux/arm64/sonobuoy-img-linux-arm64-${{ github.run_id }}.tar
           docker image ls


### PR DESCRIPTION
Signed-off-by: John Schnake <jschnake@vmware.com>

Just didn't catch this since it was in the push job, run only against master/tags.

Just confirmed this fix worked on my own fork though after merging: https://github.com/johnSchnake/sonobuoy/actions/runs/835797345