### PR TITLE
Add netapi32.dll to windows images

### DIFF
--- a/DockerfileWindows
+++ b/DockerfileWindows
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
-FROM ${BASEIMAGE}
+ARG VERSION
+FROM mcr.microsoft.com/windows/servercore:$VERSION as core
+FROM mcr.microsoft.com/windows/nanoserver:$VERSION
+COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 
 ADD build/windows/amd64/sonobuoy.exe /sonobuoy.exe
 WORKDIR /

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -85,13 +85,12 @@ build_container_dockerfile_arch() {
 }
 
 buildx_container_windows_version(){
-    BASEIMAGE="$WIN_AMD64_BASEIMAGE:$1"
     mkdir -p "build/windows/$WIN_ARCH/$VERSION"
     docker buildx build --pull \
         --output=type=oci,dest=build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar \
         --platform windows/amd64 \
         -t $REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_VERSION \
-        --build-arg BASEIMAGE=$BASEIMAGE \
+        --build-arg VERSION=$1 \
         -f build/windows/$WIN_ARCH/Dockerfile \
         .
 }


### PR DESCRIPTION
This missing dll is required to run may containerized golang apps
since anything checking the current user via the os package
relies on this. It so happens that klog does this and so its common
for some dependency to end up with the issue.

We can continue to shift to klog/v2 which may fix the issue, but
it would could get hit via another import as well.

Fixes #1263

Signed-off-by: John Schnake <jschnake@vmware.com>

