### PR TITLE
Fix multiple Windows tar issues 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
-	github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d h1:Z8Bp/K+wf1+IUvu5Vk2Ml/mMI7fmZTT7rQjkLC8pAmQ=
-github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d/go.mod h1:8uo3DXfN526YN7JjAp4JkOMm4foTW4vPzPHaAzb4xiY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/pkg/client/results/reader.go
+++ b/pkg/client/results/reader.go
@@ -23,12 +23,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 
@@ -210,7 +211,7 @@ func (r *Reader) WalkFiles(walkfn filepath.WalkFunc) error {
 			header.FileInfo(),
 			tr,
 		}
-		err = walkfn(filepath.Clean(header.Name), info, err)
+		err = walkfn(path.Clean(header.Name), info, err)
 	}
 
 	if err == errStopWalk || err == io.EOF {
@@ -290,7 +291,7 @@ func (r *Reader) Metadata() string {
 func (r *Reader) ServerVersionFile() string {
 	switch r.Version {
 	case VersionEight:
-		return "serverversion/serverversion.json"
+		return path.Join("serverversion", "serverversion.json")
 	default:
 		return defaultServerVersionFile
 	}
@@ -306,7 +307,7 @@ func (r *Reader) NamespacedResources() string {
 func (r *Reader) NonNamespacedResources() string {
 	switch r.Version {
 	case VersionEight:
-		return "resources/non-ns/"
+		return path.Join("resources", "non-ns")
 	default:
 		return nonNamespacedResourcesDir
 	}
@@ -315,7 +316,7 @@ func (r *Reader) NonNamespacedResources() string {
 // NodesFile returns the path to the file that lists the nodes of the Kubernetes
 // cluster.
 func (r *Reader) NodesFile() string {
-	return filepath.Join(r.NonNamespacedResources(), defaultNodesFile)
+	return path.Join(r.NonNamespacedResources(), defaultNodesFile)
 }
 
 // ServerGroupsFile returns the path to the groups the Kubernetes API supported at the time of the run.
@@ -330,7 +331,7 @@ func ConfigFile(version string) string {
 	case VersionEight:
 		return "config.json"
 	default:
-		return "meta/config.json"
+		return path.Join("meta", "config.json")
 	}
 }
 

--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -19,7 +19,7 @@ package discovery
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
@@ -149,9 +149,9 @@ func QueryResources(
 	}
 
 	// 1. Create the parent directory we will use to store the results
-	outdir := path.Join(cfg.OutputDir(), ClusterResourceLocation)
+	outdir := filepath.Join(cfg.OutputDir(), ClusterResourceLocation)
 	if ns != nil {
-		outdir = path.Join(cfg.OutputDir(), NSResourceLocation, *ns)
+		outdir = filepath.Join(cfg.OutputDir(), NSResourceLocation, *ns)
 	}
 
 	if err := os.MkdirAll(outdir, 0755); err != nil {
@@ -189,7 +189,7 @@ func QueryResources(
 
 		query := func() (time.Duration, error) {
 			return timedListQuery(
-				outdir+"/",
+				outdir,
 				groupText+"_"+gvr.Version+"_"+gvr.Resource+".json",
 				lister,
 			)

--- a/pkg/plugin/aggregation/aggregator_test.go
+++ b/pkg/plugin/aggregation/aggregator_test.go
@@ -33,10 +33,10 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
-	"github.com/viniciuschiele/tarx"
 	"github.com/vmware-tanzu/sonobuoy/pkg/backplane/ca/authtest"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin"
 	pluginutils "github.com/vmware-tanzu/sonobuoy/pkg/plugin/driver/utils"
+	"github.com/vmware-tanzu/sonobuoy/pkg/tarball"
 )
 
 func TestAggregation(t *testing.T) {
@@ -491,7 +491,7 @@ func makeTarWithContents(t *testing.T, filename string, fileContents []byte) (ta
 		return
 	}
 
-	err = tarx.Compress(tarfile, tardir, &tarx.CompressOptions{Compression: tarx.Gzip})
+	err = tarball.DirToTarball(tardir, tarfile, true)
 	if err != nil {
 		t.Fatalf("Could not create tar file %v: %v", tarfile, err)
 		return

--- a/pkg/tarball/tarball.go
+++ b/pkg/tarball/tarball.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -49,13 +51,13 @@ func DecodeTarball(reader io.Reader, baseDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(path.Join(baseDir, name), os.FileMode(header.Mode)); err != nil {
+			if err := os.MkdirAll(filepath.Join(baseDir, name), os.FileMode(header.Mode)); err != nil {
 				return errors.Wrap(err, "error decoding tarball for result (mkdir)")
 			}
 		case tar.TypeReg, tar.TypeRegA:
-			filePath := path.Join(baseDir, name)
+			filePath := filepath.Join(baseDir, name)
 			// Directory should come first, but some tarballes are malformed
-			if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 				return errors.Wrap(err, "error decoding tarball for result (mkdir)")
 			}
 			file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
@@ -66,14 +68,17 @@ func DecodeTarball(reader io.Reader, baseDir string) error {
 				return errors.Wrap(err, "error decoding tarball for result (copy)")
 			}
 		case tar.TypeSymlink:
-			filePath := path.Join(baseDir, name)
+			if !noTraversal(name, baseDir) {
+				return errors.Wrapf(err, "unsafe symlink detected in name: %v", name)
+			}
+			filePath := filepath.Join(baseDir, name)
 			// Directory should come first, but some tarballes are malformed
-			if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 				return errors.Wrapf(err, "error decoding tarball for result (mkdir)")
 			}
 			if err := os.Symlink(
-				path.Join(baseDir, path.Clean(header.Linkname)),
-				path.Join(baseDir, name),
+				filepath.Join(baseDir, path.Clean(header.Linkname)),
+				filepath.Join(baseDir, name),
 			); err != nil {
 				return errors.Wrap(err, "error decoding tarball for result (ln)")
 			}
@@ -82,4 +87,91 @@ func DecodeTarball(reader io.Reader, baseDir string) error {
 	}
 
 	return nil
+}
+
+// noTraversal is an ultra-slimmed down function to
+// avoid traversals outside the destination folder.
+// moby and other repos have much more complex versions
+// while this aims at removing the ability to symlink to ".."
+// entirely so that it is dead simple. I don't think for our needs
+// we really require symlinks much anyways.
+// Resolves go/unsafe-unzip-symlink codeQL check.
+func noTraversal(candidate, target string) bool {
+	if filepath.IsAbs(candidate) {
+		return false
+	}
+	return !strings.Contains(candidate, "..")
+}
+
+// DirToTarball tars up an entire directory and outputs the tarball to the specified output path.
+// If useGzip is true, it also gzips the resulting tarball.
+func DirToTarball(dir, outpath string, useGzip bool) error {
+	// ensure the src actually exists before trying to tar it
+	if _, err := os.Stat(dir); err != nil {
+		return errors.Wrapf(err, "tar unable to stat directory %v", dir)
+	}
+
+	outfile, err := os.Create(outpath)
+	if err != nil {
+		return errors.Wrapf(err, "creating tarball %v", outpath)
+	}
+	defer outfile.Close()
+
+	var tw *tar.Writer
+	if useGzip {
+		gzw := gzip.NewWriter(outfile)
+		defer gzw.Close()
+		tw = tar.NewWriter(gzw)
+	} else {
+		tw = tar.NewWriter(outfile)
+	}
+	defer tw.Close()
+
+	return filepath.Walk(dir, func(file string, fi os.FileInfo, err error) error {
+		// Return on any error.
+		if err != nil {
+			return err
+		}
+
+		// Don't include the archive or dir itself.
+		if filepath.Join(dir, fi.Name()) == outpath ||
+			filepath.Clean(file) == filepath.Clean(dir) {
+			return nil
+		}
+
+		// Dirs and files; fix invalid handle issue?
+		if !fi.Mode().IsRegular() && !fi.Mode().IsDir() {
+			return nil
+		}
+
+		// Create a new dir/file header.
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return errors.Wrapf(err, "creating file info header %v", fi.Name())
+		}
+
+		// Update the name to correctly reflect the desired destination when untaring.
+		// 1. Remove directory prefix and leading /
+		// 2: Store with Unix path seperators
+		// 3: Clean
+		header.Name = strings.TrimPrefix(path.Clean(filepath.ToSlash(strings.Replace(file, dir, "", -1))), "/")
+		if err := tw.WriteHeader(header); err != nil {
+			return errors.Wrapf(err, "writing header for tarball %v", header.Name)
+		}
+
+		// Only copy contents of regular files
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		// Open files, copy into tarfile, and close.
+		f, err := os.Open(file)
+		if err != nil {
+			return errors.Wrapf(err, "opening file %v for writing into tarball", file)
+		}
+		defer f.Close()
+
+		_, err = io.Copy(tw, f)
+		return errors.Wrapf(err, "creating file %v contents into tarball", file)
+	})
 }

--- a/pkg/tarball/tarball_test.go
+++ b/pkg/tarball/tarball_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -131,7 +132,7 @@ func TestDecodeTarball(t *testing.T) {
 				t.Fatalf("Unexpected error %v", err)
 			}
 
-			contents, err := ioutil.ReadFile(path.Join(dir, dirName, fileName))
+			contents, err := ioutil.ReadFile(filepath.Join(dir, dirName, fileName))
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}
@@ -139,7 +140,7 @@ func TestDecodeTarball(t *testing.T) {
 			if !reflect.DeepEqual(contents, testData) {
 				t.Errorf("Expected %s, got %s", testData, contents)
 			}
-			contents, err = ioutil.ReadFile(path.Join(dir, dirName, symLinkName))
+			contents, err = ioutil.ReadFile(filepath.Join(dir, dirName, symLinkName))
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}

--- a/test/integration/testImage/src/tarResults.go
+++ b/test/integration/testImage/src/tarResults.go
@@ -17,14 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/viniciuschiele/tarx"
 )
 
 var cmdTarFile = &cobra.Command{
@@ -55,7 +59,7 @@ func reportTarFile(cmd *cobra.Command, args []string) error {
 
 	// Create tarball.
 	tb := filepath.Join(resultsDir, "results.tar.gz")
-	err = tarx.Compress(tb, outPath, &tarx.CompressOptions{Compression: tarx.Gzip})
+	err = tarDir(outPath, tb, true)
 	if err != nil {
 		return errors.Wrap(err, "failed to create tarball")
 	}
@@ -63,4 +67,81 @@ func reportTarFile(cmd *cobra.Command, args []string) error {
 	// Report location to Sonobuoy.
 	err = ioutil.WriteFile(doneFile, []byte(tb), os.FileMode(0666))
 	return errors.Wrap(err, "failed to write to done file")
+}
+
+// tarDir tars up an entire directory and outputs the tarball to the specified output path.
+// If useGzip is true, it also gzips the resulting tarball.
+// NOTE: Copied from sonobuoy itself; duplicated since this is a separate binary/project
+// so it messed with the build when introducing this method the first time.
+// TODO(jschnake): After initial commit in Sonobuoy; just import/reference that method. Just
+// couldn't introduce to sonobuoy and reference it here at the same time.
+func tarDir(dir, outpath string, useGzip bool) error {
+	// ensure the src actually exists before trying to tar it
+	if _, err := os.Stat(dir); err != nil {
+		return errors.Wrapf(err, "tar unable to stat directory %v", dir)
+	}
+
+	outfile, err := os.Create(outpath)
+	if err != nil {
+		return errors.Wrapf(err, "creating tarball %v", outpath)
+	}
+	defer outfile.Close()
+
+	var tw *tar.Writer
+	if useGzip {
+		gzw := gzip.NewWriter(outfile)
+		defer gzw.Close()
+		tw = tar.NewWriter(gzw)
+	} else {
+		tw = tar.NewWriter(outfile)
+	}
+	defer tw.Close()
+
+	return filepath.Walk(dir, func(file string, fi os.FileInfo, err error) error {
+		// Return on any error.
+		if err != nil {
+			return err
+		}
+
+		// Don't include the archive or dir itself.
+		if filepath.Join(dir, fi.Name()) == outpath ||
+			filepath.Clean(file) == filepath.Clean(dir) {
+			return nil
+		}
+
+		// Dirs and files; fix invalid handle issue?
+		if !fi.Mode().IsRegular() && !fi.Mode().IsDir() {
+			return nil
+		}
+
+		// Create a new dir/file header.
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return errors.Wrapf(err, "creating file info header %v", fi.Name())
+		}
+
+		// Update the name to correctly reflect the desired destination when untaring.
+		// 1. Remove directory prefix and leading /
+		// 2: Store with Unix path seperators
+		// 3: Clean
+		header.Name = strings.TrimPrefix(path.Clean(filepath.ToSlash(strings.Replace(file, dir, "", -1))), "/")
+		if err := tw.WriteHeader(header); err != nil {
+			return errors.Wrapf(err, "writing header for tarball %v", header.Name)
+		}
+
+		// Only copy contents of regular files
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		// Open files, copy into tarfile, and close.
+		f, err := os.Open(file)
+		if err != nil {
+			return errors.Wrapf(err, "opening file %v for writing into tarball", file)
+		}
+		defer f.Close()
+
+		_, err = io.Copy(tw, f)
+		return errors.Wrapf(err, "creating file %v contents into tarball", file)
+	})
 }


### PR DESCRIPTION
- When on the server side handling files, use filepath
- When loading files into the tarball, use path
- When on the clientside use filepath
- Use our own tar logic to avoid tarx and bugs with path/filepath
- Use splat on Windows as we do for linux. TODO (not on this PR): avoid reading entire tar into memory, for large runs that will cause an issue I'm pretty sure. Tarballs can get very big when you have 100 nodes and run tests for hours.