### PR TITLE
Fix sonobuoy 101 link on site

### DIFF
--- a/site/themes/sonobuoy/layouts/index.html
+++ b/site/themes/sonobuoy/layouts/index.html
@@ -5,7 +5,7 @@
 		<div class="bg-grey introduction">
 			<div class="wrapper grid two">
 				<div class="col">
-					<p class="strong"><a href="/posts/2019-05-13-sonobuoy-101/">An Introduction to Sonobuoy</a></p>
+					<p class="strong"><a href="/sonobuoy-101/">An Introduction to Sonobuoy</a></p>
 					<p>Read an overview of the Sonobuoy project, including key use cases and how to get involved.</p>
 				</div>
 				<div class="col">


### PR DESCRIPTION
Linked to /posts/ instead of blog or just the post name itself. Probably just from the first iteration of the site.

Fixes #1261

Signed-off-by: John Schnake <jschnake@vmware.com>