### PR TITLE
Add node selector option when generating plugin spec

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -101,6 +101,32 @@ func TestPluginGenDef(t *testing.T) {
 				},
 			},
 			expectFile: "testdata/pluginDef-default-podspec.golden",
+		}, {
+			desc: "nodeSelectors works if default PodSpec is requested",
+			cfg: GenPluginDefConfig{
+				showDefaultPodSpec: true,
+				nodeSelector:       map[string]string{"foo": "bar", "kubernetes.io/os": "windows"},
+				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{
+						PluginName: "n",
+					},
+					Spec: manifest.Container{},
+				},
+			},
+			expectFile: "testdata/pluginDef-nodeselector-default-podspec.golden",
+		}, {
+			desc: "nodeSelectors works if default PodSpec is not requested",
+			cfg: GenPluginDefConfig{
+				showDefaultPodSpec: true,
+				nodeSelector:       map[string]string{"foo": "bar", "kubernetes.io/os": "windows"},
+				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{
+						PluginName: "n",
+					},
+					Spec: manifest.Container{},
+				},
+			},
+			expectFile: "testdata/pluginDef-nodeselector.golden",
 		},
 	}
 	for _, tC := range testCases {

--- a/cmd/sonobuoy/app/testdata/pluginDef-nodeselector-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-nodeselector-default-podspec.golden
@@ -1,0 +1,21 @@
+podSpec:
+  containers: []
+  nodeSelector:
+    foo: bar
+    kubernetes.io/os: windows
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
+sonobuoy-config:
+  driver: ""
+  plugin-name: "n"
+spec:
+  name: ""
+  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-nodeselector.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-nodeselector.golden
@@ -1,0 +1,21 @@
+podSpec:
+  containers: []
+  nodeSelector:
+    foo: bar
+    kubernetes.io/os: windows
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
+sonobuoy-config:
+  driver: ""
+  plugin-name: "n"
+spec:
+  name: ""
+  resources: {}

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin"
+	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/driver"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
 	manifesthelper "github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest/helper"
 	"github.com/vmware-tanzu/sonobuoy/pkg/templates"
@@ -313,6 +314,10 @@ func E2EManifest(cfg *GenConfig) *manifest.Manifest {
 			},
 		},
 	}
+	m.PodSpec = &manifest.PodSpec{
+		PodSpec: driver.DefaultPodSpec(m.SonobuoyConfig.Driver),
+	}
+	m.PodSpec.PodSpec.NodeSelector = map[string]string{"kubernetes.io/os": "linux"}
 
 	// Add volume mount, volume, and env var for custom registries.
 	if len(cfg.E2EConfig.CustomRegistries) > 0 {

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -29,6 +29,8 @@ data:
   plugin-0.yaml: |
     podSpec:
       containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
       restartPolicy: Never
       serviceAccountName: sonobuoy-serviceaccount
       tolerations:

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -27,6 +27,20 @@ metadata:
 apiVersion: v1
 data:
   plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -41,6 +41,20 @@ data:
       secret:
         defaultMode: 256
         secretName: ssh-key
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -136,10 +136,12 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 		podSpec.Volumes = append(podSpec.Volumes, v.Volume)
 	}
 
-	// TODO revise this once we support windows nodes, https://github.com/vmware-tanzu/sonobuoy/issues/732
-	pod.Spec.NodeSelector = map[string]string{
-			"kubernetes.io/os": "linux",
+	// Default for jobs to run on linux. If a plugin can run on Windows (the more rare case)
+	// they should specify it in their podSpec. This should avoid more problems than it creates.
+	podSpec.NodeSelector = map[string]string{
+		"kubernetes.io/os": "linux",
 	}
+
 	pod.Spec = podSpec
 	return pod
 }


### PR DESCRIPTION
By default jobs can run on Linux nodes (thats fine) but
if we expect users to specify the node selectors for
Windows we should make it simple to add that bit.

Fixes #1275

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Adds a new flag: sonobuoy gen plugin --node-selector foo=bar to facilitate creating windows plugins more easily.
```
