### PR TITLE
Remove coloring for codeblocks in blog

### DIFF
--- a/site/themes/sonobuoy/assets/scss/_components.scss
+++ b/site/themes/sonobuoy/assets/scss/_components.scss
@@ -351,7 +351,6 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $darkgrey;
             padding: 2px 8px;
         }
         pre {


### PR DESCRIPTION
The darkgrey was chosen, presumablu, because small bits
of code look good. However, in a large code block the background
is black and so the dark grey is nearly invisible.

Changing it to lightgrey or the like makes the blocks look good
but not the short snippets.

Rather than modify the blocks separately, removing this property
in general makes both look good in my opinion.

Signed-off-by: John Schnake <jschnake@vmware.com>
