### PR TITLE
Fix nodeSelector logic

### DIFF
--- a/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
@@ -1,5 +1,7 @@
 podSpec:
   containers: []
+  nodeSelector:
+    kubernetes.io/os: linux
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
   tolerations:

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -276,6 +276,12 @@ func defaultJobPodSpec() v1.PodSpec {
 			},
 		},
 		Volumes: []v1.Volume{},
+
+		// Default for jobs to run on linux. If a plugin can run on Windows (the more rare case)
+		// they should specify it in their podSpec. This should avoid more problems than it creates.
+		NodeSelector: map[string]string{
+			"kubernetes.io/os": "linux",
+		},
 	}
 }
 

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -136,12 +136,6 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 		podSpec.Volumes = append(podSpec.Volumes, v.Volume)
 	}
 
-	// Default for jobs to run on linux. If a plugin can run on Windows (the more rare case)
-	// they should specify it in their podSpec. This should avoid more problems than it creates.
-	podSpec.NodeSelector = map[string]string{
-		"kubernetes.io/os": "linux",
-	}
-
 	pod.Spec = podSpec
 	return pod
 }

--- a/pkg/plugin/driver/job/job_test.go
+++ b/pkg/plugin/driver/job/job_test.go
@@ -212,6 +212,10 @@ func TestCreatePodDefinitionUsesDefaultPodSpec(t *testing.T) {
 	if actualNumTolerations != expectedNumTolerations {
 		t.Errorf("expected pod spec to %v tolerations, got %v", expectedNumTolerations, actualNumTolerations)
 	}
+
+	if len(pod.Spec.NodeSelector) != 1 || pod.Spec.NodeSelector["kubernetes.io/os"] != "linux" {
+		t.Errorf("Expected node selector kubernetes.io/os:linux but got %v", pod.Spec.NodeSelector)
+	}
 }
 
 func TestCreatePodDefinitionUsesProvidedPodSpec(t *testing.T) {
@@ -226,7 +230,10 @@ func TestCreatePodDefinitionUsesProvidedPodSpec(t *testing.T) {
 			},
 		},
 		PodSpec: &manifest.PodSpec{
-			PodSpec: corev1.PodSpec{ServiceAccountName: expectedServiceAccountName},
+			PodSpec: corev1.PodSpec{
+				ServiceAccountName: expectedServiceAccountName,
+				NodeSelector:       map[string]string{"foo": "bar"},
+			},
 		},
 	}
 	testPlugin := NewPlugin(m, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{})
@@ -240,7 +247,10 @@ func TestCreatePodDefinitionUsesProvidedPodSpec(t *testing.T) {
 
 	if pod.Spec.ServiceAccountName != expectedServiceAccountName {
 		t.Errorf("expected pod spec to have provided service account name %q, got %q", expectedServiceAccountName, pod.Spec.ServiceAccountName)
+	}
 
+	if len(pod.Spec.NodeSelector) != 1 || pod.Spec.NodeSelector["foo"] != "bar" {
+		t.Errorf("Expected node selector foo:bar but got %v", pod.Spec.NodeSelector)
 	}
 }
 


### PR DESCRIPTION
The logic for this was previously broken, but when fixed, it
was found to actually be implemented incorrectly causing it to
overwrite the nodeSelector in all cases, not just when the podSpec
was empty.

Now it just updates the nodeSelector to linux boxes when there is
no podspec given by the user. If they want to specify a podspec to
force it to a different os (or any os) then they can do so.

Tests added to prevent this issue from regression.

Signed-off-by: John Schnake <jschnake@vmware.com>