### PR TITLE
Fix detailed results view if results from Windows node

### DIFF
--- a/cmd/sonobuoy/app/results.go
+++ b/cmd/sonobuoy/app/results.go
@@ -44,6 +44,8 @@ const (
 
 	// resultModeDump will just copy the post-processed yaml file to stdout.
 	resultModeDump = "dump"
+
+	windowsSeperator = `\`
 )
 
 type resultsInput struct {
@@ -313,9 +315,19 @@ func walkForSummary(result *results.Item, statusCounts map[string]int, failList 
 	return statusCounts, failList
 }
 
+// getFileFromMeta pulls the file out of the given metadata but also
+// converts it to a slash-based-seperator since that is what is internal
+// to the tar file. The metadata is written by the node and so may use
+// Windows seperators.
 func getFileFromMeta(m map[string]string) string {
 	if m == nil {
 		return ""
 	}
-	return m["file"]
+	return toSlash(m["file"])
+}
+
+// toSlash is a (for our purpose) an improved version of filepath.ToSlash which ignores the
+// current OS seperator and simply converts all windows `\` to `/`.
+func toSlash(path string) string {
+	return strings.ReplaceAll(path, string(windowsSeperator), "/")
 }

--- a/cmd/sonobuoy/app/results_test.go
+++ b/cmd/sonobuoy/app/results_test.go
@@ -17,7 +17,43 @@ package app
 
 import (
 	"path/filepath"
+	"testing"
 )
+
+func TestGetFileFromMeta(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		input    map[string]string
+		expected string
+	}{
+		{
+			desc:     "Nil map",
+			input:    nil,
+			expected: "",
+		}, {
+			desc:     "Empty",
+			input:    map[string]string{},
+			expected: "",
+		}, {
+			desc:     "File with slash",
+			input:    map[string]string{"file": "a/b/c"},
+			expected: "a/b/c",
+		}, {
+			desc:     "File with windows seperators",
+			input:    map[string]string{"file": `a\b\c`},
+			expected: "a/b/c",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := getFileFromMeta(tc.input)
+			if out != tc.expected {
+				t.Errorf("Expected %v but got %v", tc.expected, out)
+			}
+		})
+	}
+}
 
 func ExampleNewCmdResults() {
 	cmd := NewCmdResults()


### PR DESCRIPTION
Fixes the problem where the metadata may point to the
results files using os-specific separators. However, within
the tarball slashes are used so we need to convert the best
we can.

Fixes #1274

Signed-off-by: John Schnake <jschnake@vmware.com>


**Release note**:
```
Fixed the problem where sonobuoy results --mode=detailed would not work if the aggregator was on a Windows machine.
```
