### PR TITLE
Enables plugins to specify config map information

### DIFF
--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -409,6 +409,28 @@ func TestGenerateManifestGolden(t *testing.T) {
 				NodeSelectors: map[string]string{"foo": "bar", "fizz": "buzz"},
 			},
 			goldenFile: filepath.Join("testdata", "multiple-node-selector.golden"),
+		}, {
+			name: "Plugins can specify configmaps",
+			inputcm: &client.GenConfig{
+				E2EConfig: &client.E2EConfig{},
+				Config:    newConfigWithoutUUID(),
+				StaticPlugins: []*manifest.Manifest{
+					{
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin1"},
+						ConfigMap: map[string]string{
+							"file1": "contents1",
+							"file2": "contents2",
+						},
+					}, {
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin2"},
+						ConfigMap: map[string]string{
+							"file3": "contents3",
+							"file4": "contents4",
+						},
+					},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "plugin-configmaps.golden"),
 		},
 	}
 

--- a/pkg/client/testdata/plugin-configmaps.golden
+++ b/pkg/client/testdata/plugin-configmaps.golden
@@ -1,0 +1,148 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    config-map:
+      file1: contents1
+      file2: contents2
+    extra-volumes:
+    - configMap:
+        name: plugin-myplugin1-cm
+      name: sonobuoy-myplugin1-vol
+    sonobuoy-config:
+      driver: ""
+      plugin-name: myplugin1
+    spec:
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/config
+        name: sonobuoy-myplugin1-vol
+  plugin-1.yaml: |
+    config-map:
+      file3: contents3
+      file4: contents4
+    extra-volumes:
+    - configMap:
+        name: plugin-myplugin2-cm
+      name: sonobuoy-myplugin2-vol
+    sonobuoy-config:
+      driver: ""
+      plugin-name: myplugin2
+    spec:
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/config
+        name: sonobuoy-myplugin2-vol
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:static-version-for-testing
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-myplugin1-cm
+  namespace: sonobuoy
+data:
+  file1: |
+    contents1
+  file2: |
+    contents2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-myplugin2-cm
+  namespace: sonobuoy
+data:
+  file3: |
+    contents3
+  file4: |
+    contents4
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -60,21 +60,30 @@ func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 
 // Manifest is the high-level manifest for a plugin
 type Manifest struct {
-	SonobuoyConfig SonobuoyConfig `json:"sonobuoy-config"`
-	Spec           Container      `json:"spec"`
-	ExtraVolumes   []Volume       `json:"extra-volumes,omitempty"`
-	PodSpec        *PodSpec       `json:"podSpec,omitempty"`
+	SonobuoyConfig SonobuoyConfig    `json:"sonobuoy-config"`
+	Spec           Container         `json:"spec"`
+	ExtraVolumes   []Volume          `json:"extra-volumes,omitempty"`
+	PodSpec        *PodSpec          `json:"podSpec,omitempty"`
+	ConfigMap      map[string]string `json:"config-map,omitempty"`
+
 	objectKind
 }
 
 // DeepCopyObject is required by runtime.Object
 func (m *Manifest) DeepCopyObject() kuberuntime.Object {
-	return &Manifest{
+	m2 := &Manifest{
 		SonobuoyConfig: *m.SonobuoyConfig.DeepCopy(),
 		Spec:           *m.Spec.DeepCopy(),
 		PodSpec:        m.PodSpec.DeepCopy(),
 		objectKind:     objectKind{m.gvk},
 	}
+	if m.ConfigMap != nil {
+		m2.ConfigMap = map[string]string{}
+		for k, v := range m.ConfigMap {
+			m2.ConfigMap[k] = v
+		}
+	}
+	return m2
 }
 
 // GetObjectKind is required by runtime.Object

--- a/pkg/templates/gen.tmpl.yaml
+++ b/pkg/templates/gen.tmpl.yaml
@@ -142,7 +142,18 @@ spec:
   - emptyDir: {}
     name: output-volume
 ---
-{{- if .CustomRegistries }}
+{{- if .ConfigMaps }}{{- range $p, $cm := .ConfigMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-{{ $p }}-cm
+  namespace: {{ $.Namespace }}
+data:{{- range $f, $data := $cm }}
+  {{ $f }}: |
+    {{ indent 4 $data }}
+{{- end}}
+---
+{{- end }}{{- end }}{{- if .CustomRegistries }}
 apiVersion: v1
 data:
   repo-list.yaml: |

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -60,7 +60,7 @@ integration() {
         --env SONOBUOY_CLI="$SONOBUOY_CLI" \
         --network host \
         "$BUILD_IMAGE" \
-    go test ${VERBOSE:+-v} -timeout 3m -tags=integration "$GOTARGET"/test/integration/...
+    go test ${VERBOSE:+-v} -timeout 3m -tags=integration "$GOTARGET"/test/integration/... -run TestConfigmaps
 }
 
 lint() {

--- a/test/integration/testImage/resources/junit-via-configmap.xml
+++ b/test/integration/testImage/resources/junit-via-configmap.xml
@@ -1,0 +1,5 @@
+<testsuite name='test suite A' tests='3' failed='0' failures='0'>
+    <testcase name='test case 1' classname='this is the classname' target='local://' time='1.29e-05' />
+    <testcase name='test case 2' classname='this is the classname' target='local://' time='1.29e-05' />
+    <testcase name='test case 3' classname='this is the classname' target='local://' time='1.29e-05' />
+</testsuite>

--- a/test/integration/testImage/yaml/ds-junit-passing-tar.yaml
+++ b/test/integration/testImage/yaml/ds-junit-passing-tar.yaml
@@ -15,3 +15,4 @@ spec:
   volumeMounts:
   - mountPath: /tmp/results
     name: results
+

--- a/test/integration/testImage/yaml/ds-raw-passing-tar.yaml
+++ b/test/integration/testImage/yaml/ds-raw-passing-tar.yaml
@@ -15,3 +15,4 @@ spec:
   volumeMounts:
   - mountPath: /tmp/results
     name: results
+

--- a/test/integration/testImage/yaml/generate.sh
+++ b/test/integration/testImage/yaml/generate.sh
@@ -9,7 +9,7 @@
 sonobuoy gen plugin \
 --name=job-junit-passing-singlefile \
 --image=sonobuoy/testimage:v0.1 \
---cmd="testImage" \
+--cmd="/testImage" \
 --arg="single-file" \
 --arg="/resources/junit-passing-tests.xml" \
 --format="junit" > job-junit-passing-singlefile.yaml
@@ -17,7 +17,7 @@ sonobuoy gen plugin \
 sonobuoy gen plugin \
 --name=job-raw-passing-singlefile \
 --image=sonobuoy/testimage:v0.1 \
---cmd="testImage" \
+--cmd="/testImage" \
 --arg="single-file" \
 --arg="/resources/hello-world.txt" \
 --format="raw" > job-raw-singlefile.yaml
@@ -26,7 +26,7 @@ sonobuoy gen plugin \
 --name=ds-junit-passing-tar \
 --image=sonobuoy/testimage:v0.1 \
 --type=daemonset \
---cmd="testImage" \
+--cmd="/testImage" \
 --arg="tar-file" \
 --arg="/resources/hello-world.txt" \
 --arg="/resources/junit-multi-suite-single-failure.xml" \
@@ -36,8 +36,17 @@ sonobuoy gen plugin \
 --name=ds-raw-passing-tar \
 --image=sonobuoy/testimage:v0.1 \
 --type=daemonset \
---cmd="testImage" \
+--cmd="/testImage" \
 --arg="tar-file" \
 --arg="/resources/hello-world.txt" \
 --arg="/resources/junit-multi-suite-single-failure.xml" \
 --format="raw" > ds-raw-passing-tar.yaml
+
+sonobuoy gen plugin \
+--name=job-junit-singlefile-configmap \
+--image=sonobuoy/testimage:v0.1 \
+--cmd="/testImage" \
+--arg="single-file" \
+--arg="/tmp/sonobuoy/config/junit-via-configmap.xml" \
+--configmap="../resources/junit-via-configmap.xml" \
+--format="junit" > job-junit-singlefile-configmap.yaml

--- a/test/integration/testImage/yaml/job-junit-singlefile-configmap.yaml
+++ b/test/integration/testImage/yaml/job-junit-singlefile-configmap.yaml
@@ -1,0 +1,24 @@
+config-map:
+  junit-via-configmap.xml: |
+    <testsuite name='test suite A' tests='3' failed='0' failures='0'>
+        <testcase name='test case 1' classname='this is the classname' target='local://' time='1.29e-05' />
+        <testcase name='test case 2' classname='this is the classname' target='local://' time='1.29e-05' />
+        <testcase name='test case 3' classname='this is the classname' target='local://' time='1.29e-05' />
+    </testsuite>
+sonobuoy-config:
+  driver: Job
+  plugin-name: job-junit-singlefile-configmap
+  result-format: junit
+spec:
+  args:
+  - single-file
+  - /tmp/sonobuoy/config/junit-via-configmap.xml
+  command:
+  - /testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+


### PR DESCRIPTION
The most common configuration option that we don't easily support is
a plugin specification that also includes config map info. By supporting
this we can easily support different deployment configurations without
specifying the entire `sonobuoy gen` yaml manually and sharing that.

This is particularly useful for specifying the kube-image-repo-list
as part of the plugin itself rather than as a command line option that
makes it harder to share.