### PR TITLE
Expands timeout error message to try and clarify action

### DIFF
--- a/pkg/plugin/constants.go
+++ b/pkg/plugin/constants.go
@@ -24,5 +24,5 @@ const (
 	ResultsDir = "/tmp/results"
 
 	// TimeoutErrMsg is the message used when Sonobuoy experiences a timeout while waiting for results.
-	TimeoutErrMsg = "timeout waiting for results"
+	TimeoutErrMsg = "Plugin timeout while waiting for results so there are no results. Check pod logs or other cluster details for more information as to why this occurred."
 )

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -267,7 +267,7 @@ func (p *Plugin) Monitor(ctx context.Context, kubeclient kubernetes.Interface, a
 			// nodes have returned results to the aggregator. We can report the error for every node though
 			// since the aggregator will throw out duplicate results.
 			case ctx.Err() == context.DeadlineExceeded:
-				logrus.Errorf("Timeout waiting for plugin %v", p.GetName())
+				logrus.Errorf("Timeout waiting for plugin %v. Try checking the pod logs and other data in the results tarball for more information.", p.GetName())
 				errs := makeErrorResultsForNodes(
 					p.GetName(),
 					map[string]interface{}{"error": plugin.TimeoutErrMsg},

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -173,7 +173,7 @@ func (p *Plugin) Monitor(ctx context.Context, kubeclient kubernetes.Interface, _
 		case <-ctx.Done():
 			switch {
 			case ctx.Err() == context.DeadlineExceeded:
-				logrus.Errorf("Timeout waiting for plugin %v", p.GetName())
+				logrus.Errorf("Timeout waiting for plugin %v. Try checking the pod logs and other data in the results tarball for more information.", p.GetName())
 				resultsCh <- utils.MakeErrorResult(
 					p.GetName(),
 					map[string]interface{}{"error": plugin.TimeoutErrMsg},


### PR DESCRIPTION
When a plugin times out, users can sometimes be confused what they
should do next. Was there a real problem? Rerun?

At the very least we need to instruct them to check the logs and
see if they can find more clues.

**Which issue(s) this PR fixes**
- Fixes # 1152

**Release note**:
```
Clarifies plugin timeout error message to instruct the user to check logs and that there are no results to view.
```
