### PR TITLE
Extend timeout and fix integration test invocation

### DIFF
--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -60,7 +60,7 @@ integration() {
         --env SONOBUOY_CLI="$SONOBUOY_CLI" \
         --network host \
         "$BUILD_IMAGE" \
-    go test ${VERBOSE:+-v} -timeout 3m -tags=integration "$GOTARGET"/test/integration/... -run TestConfigmaps
+    go test ${VERBOSE:+-v} -tags=integration "$GOTARGET"/test/integration/...
 }
 
 lint() {


### PR DESCRIPTION
The tests are simply getting longer in total; the 3m timeout
is not for individual tests but for the whole suite.

Using default of 10m and fixing an accidental filter on the tests.