### PR TITLE
Add configurable log levels for logrus

### DIFF
--- a/pkg/errlog/errlog.go
+++ b/pkg/errlog/errlog.go
@@ -22,8 +22,43 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// DebugOutput controls whether to output the trace of every error
-var DebugOutput = false
+var (
+	// DebugOutput controls whether to output the trace of every error
+	DebugOutput = false
+
+	// loglevel used for sirupsen/logrus
+	LogLevel = "info"
+)
+
+func SetLevel() {
+	// Just using debug to set log level for as long
+	// as we want to keep the deprecated flag.
+	if DebugOutput {
+		LogLevel = "debug"
+	}
+	switch LogLevel {
+	case "panic":
+		logrus.SetLevel(logrus.PanicLevel)
+	case "fatal":
+		logrus.SetLevel(logrus.FatalLevel)
+	case "error":
+		logrus.SetLevel(logrus.ErrorLevel)
+	case "warn":
+		logrus.SetLevel(logrus.WarnLevel)
+	case "info":
+		logrus.SetLevel(logrus.InfoLevel)
+	case "debug":
+		logrus.SetLevel(logrus.DebugLevel)
+		DebugOutput = true
+	case "trace":
+		logrus.SetLevel(logrus.TraceLevel)
+		DebugOutput = true
+	default:
+		logrus.Warningf("Unknown log level %q. Defaulting to info.", LogLevel)
+		LogLevel = "info"
+		logrus.SetLevel(logrus.InfoLevel)
+	}
+}
 
 // LogError logs an error, optionally with a tracelog
 func LogError(err error) {

--- a/pkg/image/docker/client.go
+++ b/pkg/image/docker/client.go
@@ -42,15 +42,11 @@ func (l LocalDocker) Run(image string, args ...string) ([]string, error) {
 }
 
 // PullIfNotPresent will pull an image if it is not present locally
-// retrying up to retries times
-// returns errors from pulling
+// retrying up to "retries" times. Returns errors from pulling.
 func (l LocalDocker) PullIfNotPresent(image string, retries int) error {
-	// TODO(bentheelder): switch most (all) of the logging here to debug level
-	// once we have configurable log levels
-	// if this did not return an error, then the image exists locally
 	cmd := exec.Command("docker", "inspect", "--type=image", image)
 	if err := cmd.Run(); err == nil {
-		log.Infof("Image: %s present locally", image)
+		log.Debugf("Image: %s present locally", image)
 		return nil
 	}
 	// otherwise try to pull it


### PR DESCRIPTION
- Adds string flag to set log level for logrus
- Removes todo to update some of the logging to debug
- Marks debug flag as hidden/deprecated
- Marks klog flags as hidden
- If debug flag is set, simply sets the log level to debug.

Fixes #1189

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Numerous logging flags. from klog have been marked as hidden to avoid clutter in the help menu. In addition, the --debug flag has been replaced with a --level flag that can be set to "debug" for the same effect as well as finer grain control over future logging.
```
