### PR TITLE
Fix version resolution during image pulling

### DIFF
--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -230,18 +230,18 @@ func deleteCmd() *cobra.Command {
 // getClusterVersion will return either the given string or, if empty, use the kubeconfig
 // to reach out to the server and check its version.
 func getClusterVersion(k8sVersion image.ConformanceImageVersion, kubeconfig Kubeconfig) (string, error) {
-	if len(k8sVersion.String()) > 0 {
+	if len(k8sVersion.String()) > 0 && k8sVersion != image.ConformanceImageVersionAuto {
 		return k8sVersion.String(), nil
 	}
 
 	sbc, err := getSonobuoyClientFromKubecfg(kubeconfig)
 	if err != nil {
-		return "", errors.Wrap(err, "couldn't create sonobuoy client")
+		return "", errors.Wrap(err, "couldn't create sonobuoy client in order to check Kubernetes version")
 	}
 
 	version, err := sbc.Version()
 	if err != nil {
-		return "", errors.Wrap(err, "couldn't get Sonobuoy client")
+		return "", errors.Wrap(err, "couldn't determine Kubernetes version from cluster")
 	}
 
 	return version, nil

--- a/cmd/sonobuoy/app/images_test.go
+++ b/cmd/sonobuoy/app/images_test.go
@@ -72,3 +72,41 @@ func TestConvertImagesToPairs(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetClusterVersion(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		input     image.ConformanceImageVersion
+		expect    string
+		expectErr bool
+	}{
+		{
+			desc:      "Empty gets resolved (which will fail here)",
+			input:     image.ConformanceImageVersion(""),
+			expectErr: true,
+		}, {
+			desc:      "auto gets resolved (which will fail here)",
+			input:     image.ConformanceImageVersion("auto"),
+			expectErr: true,
+		}, {
+			desc:   "Other text gets returned without error",
+			input:  image.ConformanceImageVersion("foo"),
+			expect: "foo",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			output, err := getClusterVersion(tc.input, Kubeconfig{})
+			switch {
+			case err != nil && !tc.expectErr:
+				t.Fatalf("Expected no error but got %v", err)
+			case err == nil && tc.expectErr:
+				t.Fatalf("Expected error but got none")
+			}
+
+			if output != tc.expect {
+				t.Errorf("Expected %v but got %v", tc.expect, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The merging of kubernetes-version and kube-conformance-image-version
flags left the `sonobuoy images` command with improper resolution in
the default case.

There were previously no tests for this logic. This change fixes
the logic to resolve the new 'auto' default and tests this.

Fixes #1324

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Fixes a bug where `sonobuoy images` failed unless `--kubernetes-version` was set (either to empty value or an explicit version).
```
