### PR TITLE
Add sleep after systemd-logs again

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -298,7 +298,7 @@ func SystemdLogsManifest(cfg *GenConfig) *manifest.Manifest {
 			Container: corev1.Container{
 				Name:            "systemd-logs",
 				Image:           cfg.SystemdLogsImage,
-				Command:         []string{"/bin/sh", "-c", `/get_systemd_logs.sh`},
+				Command:         []string{"/bin/sh", "-c", `/get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done`},
 				ImagePullPolicy: corev1.PullPolicy(cfg.ImagePullPolicy),
 				Env: []corev1.EnvVar{
 					{Name: "CHROOT_DIR", Value: "/node"},

--- a/pkg/client/testdata/custom-systemd-logs-image.golden
+++ b/pkg/client/testdata/custom-systemd-logs-image.golden
@@ -34,7 +34,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -67,7 +67,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -80,7 +80,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -67,7 +67,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -41,7 +41,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -67,7 +67,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -67,7 +67,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -34,7 +34,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -113,7 +113,8 @@ data:
       command:
       - /bin/sh
       - -c
-      - /get_systemd_logs.sh
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
       env:
       - name: CHROOT_DIR
         value: /node


### PR DESCRIPTION
The previous change which removed this sleep did also
ensure that the worker doesn't exit from errors so it doesn't
restart but the plugin container itself still exited and caused
a misleading pod status of CrashLoopBackOff.

That doesn't prevent anything for working but is confusing and
the sleep should be restored.

Fixes #1322

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Fixes an issue where the default systemd-logs plugin command would cause the pod to enter the CrashLoopBackOff state. This bug did not prevet the plugin from submitting results properly.
```
