### PR TITLE
Add more descriptive status output

### DIFF
--- a/cmd/sonobuoy/app/status_test.go
+++ b/cmd/sonobuoy/app/status_test.go
@@ -29,7 +29,7 @@ var expectedSummary = `         PLUGIN     STATUS   RESULT   COUNT
    systemd_logs   complete   failed       1
    systemd_logs    running                2
 
-Sonobuoy is still running. Runs can take up to 60 minutes.
+Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.
 `
 var expectedShowAll = `         PLUGIN     NODE     STATUS   RESULT
             e2e            complete   passed
@@ -37,7 +37,7 @@ var expectedShowAll = `         PLUGIN     NODE     STATUS   RESULT
    systemd_logs   node02   complete   failed
    systemd_logs   node03    running         
 
-Sonobuoy is still running. Runs can take up to 60 minutes.
+Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.
 `
 
 var exampleStatus = aggregation.Status{

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -18,22 +18,34 @@ package client
 
 import (
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
 )
 
+// GetStatus returns the aggregation status that is set as an annotation on the aggregator pod.
+// Returns an error if unable to find the namespace, pod, or annotation. Use GetStatusPod to
+// also return the pod itself so that you can better understand the state of the system.
 func (c *SonobuoyClient) GetStatus(cfg *StatusConfig) (*aggregation.Status, error) {
+	s, _, err := c.GetStatusPod(cfg)
+	return s, err
+}
+
+// GetStatus returns the aggregation status that is set as an annotation on the aggregator pod.
+// Returns an error if unable to find the namespace, pod, or annotation. Also returns the aggregator
+// pod itself so that you can check its exact status or other annotations.
+func (c *SonobuoyClient) GetStatusPod(cfg *StatusConfig) (*aggregation.Status, *corev1.Pod, error) {
 	if cfg == nil {
-		return nil, errors.New("nil StatusConfig provided")
+		return nil, nil, errors.New("nil StatusConfig provided")
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return nil, errors.Wrap(err, "config validation failed")
+		return nil, nil, errors.Wrap(err, "config validation failed")
 	}
 
 	client, err := c.Client()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return aggregation.GetStatus(client, cfg.Namespace)

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -349,7 +349,7 @@ func getPodLogNamespaceFilter(cfg *config.Config) string {
 // effect the finalized status the user sees. This does not change the
 // status of individual plugins.
 func updateStatus(client kubernetes.Interface, namespace string, status string, tarInfo *pluginaggregation.TarInfo) error {
-	podStatus, err := pluginaggregation.GetStatus(client, namespace)
+	podStatus, _, err := pluginaggregation.GetStatus(client, namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the existing status")
 	}
@@ -363,7 +363,7 @@ func updateStatus(client kubernetes.Interface, namespace string, status string, 
 }
 
 func updatePluginStatus(client kubernetes.Interface, namespace string, pluginName string, item results.Item) error {
-	podStatus, err := pluginaggregation.GetStatus(client, namespace)
+	podStatus, _, err := pluginaggregation.GetStatus(client, namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the existing status")
 	}


### PR DESCRIPTION
Whenever we do not have an aggregation status, we can still
direct the user what to do next (usually debug with kubectl).

When possible, we should be able to tell them we can't pull the
image etc to shorten their cycles.

Fixes #1328

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Improved output of `sonobuoy status` when the pod was not in the expected state to make it more clear how to proceed.
```
