### PR TITLE
Fix a unit test by avoiding local kubeconfig

### DIFF
--- a/cmd/sonobuoy/app/images_test.go
+++ b/cmd/sonobuoy/app/images_test.go
@@ -95,6 +95,9 @@ func TestGetClusterVersion(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		// Dont let actual local env impact these tests.
+		defer os.Setenv("KUBECONFIG", os.Getenv("KUBECONFIG"))
+		os.Setenv("KUBECONFIG", "/foo/bar/not/a/kubeconfig")
 		t.Run(tc.desc, func(t *testing.T) {
 			output, err := getClusterVersion(tc.input, Kubeconfig{})
 			switch {


### PR DESCRIPTION
The test naturally picks up on the local kubeconfig so we need
to intentionally set it to a "bad" value here.

Fixes #1345

Signed-off-by: John Schnake <jschnake@vmware.com>
