### PR TITLE
Add generic plugin transformations and use for kube-repo-list

### DIFF
--- a/pkg/client/defaults.go
+++ b/pkg/client/defaults.go
@@ -25,7 +25,6 @@ import (
 // NewGenConfig is a GenConfig using the default config and NonDisruptiveConformance mode
 func NewGenConfig() *GenConfig {
 	return &GenConfig{
-		E2EConfig:  &E2EConfig{},
 		Config:     config.New(),
 		EnableRBAC: true,
 	}

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -32,23 +32,20 @@ func TestGenerateManifest(t *testing.T) {
 		{
 			name: "nil config",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
-				Config:    nil,
+				Config: nil,
 			},
 			expected: &config.Config{},
 		},
 		{
 			name: "Defaults in yield a default manifest.",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
-				Config:    &config.Config{},
+				Config: &config.Config{},
 			},
 			expected: &config.Config{},
 		},
 		{
 			name: "Overriding the bind address",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: &config.Config{
 					Aggregation: plugin.AggregationConfig{
 						BindAddress: "10.0.0.1",
@@ -64,7 +61,6 @@ func TestGenerateManifest(t *testing.T) {
 		{
 			name: "Overriding the plugin selection",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: &config.Config{
 					PluginSelections: []plugin.Selection{
 						{
@@ -85,7 +81,6 @@ func TestGenerateManifest(t *testing.T) {
 		{
 			name: "The plugin search path is not modified",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: &config.Config{
 					PluginSearchPath: []string{"a", "b", "c", "a"},
 				},
@@ -167,14 +162,12 @@ func TestGenerateManifestGolden(t *testing.T) {
 		{
 			name: "Default",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
-				Config:    staticConfig(),
+				Config: staticConfig(),
 			},
 			goldenFile: filepath.Join("testdata", "default.golden"),
 		}, {
 			name: "Only e2e (legacy plugin choice)",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: fromConfig(func(c *config.Config) *config.Config {
 					c.PluginSelections = []plugin.Selection{{Name: "e2e"}}
 					return c
@@ -184,7 +177,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Only systemd_logs (legacy plugin choice)",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: fromConfig(func(c *config.Config) *config.Config {
 					c.PluginSelections = []plugin.Selection{{Name: "systemd-logs"}}
 					return c
@@ -194,7 +186,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Empty array leads to default plugins, not 0",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: fromConfig(func(c *config.Config) *config.Config {
 					c.PluginSelections = []plugin.Selection{}
 					return c
@@ -205,7 +196,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 			// For backwards compatibility.
 			name: "Nil plugin selection and no manual choice leads to e2e/systemd",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: fromConfig(func(c *config.Config) *config.Config {
 					c.PluginSelections = nil
 					return c
@@ -215,14 +205,12 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Manually specify e2e",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 			},
 			goldenFile: filepath.Join("testdata", "manual-e2e.golden"),
 		}, {
 			name: "Manually specify custom plugin",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				StaticPlugins: []*manifest.Manifest{
 					{
 						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "foo"},
@@ -233,7 +221,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Manually custom plugin and e2e plugins",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 				StaticPlugins: []*manifest.Manifest{
 					{
@@ -245,7 +232,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Manually custom plugin and systemd-logs plugins",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"systemd-logs"},
 				StaticPlugins: []*manifest.Manifest{
 					{
@@ -257,7 +243,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Duplicates plugin names fail",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				StaticPlugins: []*manifest.Manifest{
 					{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "a"}},
 					{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "a"}},
@@ -268,7 +253,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 			// In this case the server will just load both and filter like it does currently.
 			name: "Plugin selection and custom plugins both specified allowed",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
 				Config: fromConfig(func(c *config.Config) *config.Config {
 					c.PluginSelections = []plugin.Selection{
 						{
@@ -286,7 +270,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "ImagePullSecrets is set on plugins and aggregator",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 				Config: &config.Config{
 					ImagePullSecrets: "foo",
@@ -296,7 +279,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Env overrides",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 				PluginEnvOverrides: map[string]map[string]string{
 					"e2e": {"E2E_SKIP": "override", "E2E_DRYRUN": "true"},
@@ -306,7 +288,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Env overrides must match plugin names",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 				PluginEnvOverrides: map[string]map[string]string{
 					"e2e2": {"E2E_SKIP": "override", "E2E_DRYRUN": "true"},
@@ -316,14 +297,12 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Default pod spec is included if requested and no other pod spec provided",
 			inputcm: &client.GenConfig{
-				E2EConfig:          &client.E2EConfig{},
 				ShowDefaultPodSpec: true,
 			},
 			goldenFile: filepath.Join("testdata", "default-pod-spec.golden"),
 		}, {
 			name: "E2E_USE_GO_RUNNER can be overridden/removed",
 			inputcm: &client.GenConfig{
-				E2EConfig:      &client.E2EConfig{},
 				DynamicPlugins: []string{"e2e"},
 				PluginEnvOverrides: map[string]map[string]string{
 					"e2e": {"E2E_USE_GO_RUNNER": ""},
@@ -333,7 +312,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Existing pod spec is not modified if default pod spec is requested",
 			inputcm: &client.GenConfig{
-				E2EConfig:          &client.E2EConfig{},
 				ShowDefaultPodSpec: true,
 				StaticPlugins: []*manifest.Manifest{
 					{
@@ -346,7 +324,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Conformance images >= v1.17 support progress",
 			inputcm: &client.GenConfig{
-				E2EConfig:            &client.E2EConfig{},
 				DynamicPlugins:       []string{"e2e"},
 				KubeConformanceImage: "some-image:v1.17.0",
 			},
@@ -354,7 +331,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "ProgressUpdatesPort is customizable for e2e",
 			inputcm: &client.GenConfig{
-				E2EConfig:            &client.E2EConfig{},
 				DynamicPlugins:       []string{"e2e"},
 				KubeConformanceImage: "some-image:v1.17.0",
 				Config: &config.Config{
@@ -365,7 +341,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Conformance images >= v1.17 will not override E2E_EXTRA_ARGS if specified by user",
 			inputcm: &client.GenConfig{
-				E2EConfig:            &client.E2EConfig{},
 				DynamicPlugins:       []string{"e2e"},
 				KubeConformanceImage: "some-image:v1.17.0",
 				PluginEnvOverrides: map[string]map[string]string{
@@ -376,7 +351,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Custom systemd-logs image is used if specified",
 			inputcm: &client.GenConfig{
-				E2EConfig:        &client.E2EConfig{},
 				DynamicPlugins:   []string{"systemd-logs"},
 				SystemdLogsImage: "custom-systemd-logs:v1.0.0",
 			},
@@ -384,7 +358,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Node selector can be added",
 			inputcm: &client.GenConfig{
-				E2EConfig:     &client.E2EConfig{},
 				Config:        staticConfig(),
 				NodeSelectors: map[string]string{"foo": "bar"},
 			},
@@ -392,7 +365,6 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Multiple node selectors can be added",
 			inputcm: &client.GenConfig{
-				E2EConfig:     &client.E2EConfig{},
 				Config:        staticConfig(),
 				NodeSelectors: map[string]string{"foo": "bar", "fizz": "buzz"},
 			},
@@ -400,8 +372,7 @@ func TestGenerateManifestGolden(t *testing.T) {
 		}, {
 			name: "Plugins can specify configmaps",
 			inputcm: &client.GenConfig{
-				E2EConfig: &client.E2EConfig{},
-				Config:    staticConfig(),
+				Config: staticConfig(),
 				StaticPlugins: []*manifest.Manifest{
 					{
 						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin1"},
@@ -468,11 +439,6 @@ func TestGenerateManifestInvalidConfig(t *testing.T) {
 			desc:             "Passing a nil config results in an error",
 			config:           nil,
 			expectedErrorMsg: "nil GenConfig provided",
-		},
-		{
-			desc:             "Passing an invalid config with an empty namespace results in an error",
-			config:           &client.GenConfig{},
-			expectedErrorMsg: "config validation failed",
 		},
 	}
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -52,7 +52,10 @@ func (lc *LogConfig) Validate() error {
 
 // GenConfig are the input options for generating a Sonobuoy manifest.
 type GenConfig struct {
-	E2EConfig            *E2EConfig
+	// Plugin transforms allows us to lazily apply generic transformations
+	// to plugins after loading them.
+	PluginTransforms map[string][]func(*manifest.Manifest) error
+
 	Config               *config.Config
 	EnableRBAC           bool
 	ImagePullPolicy      string
@@ -91,19 +94,7 @@ type GenConfig struct {
 
 // Validate checks the config to determine if it is valid.
 func (gc *GenConfig) Validate() error {
-	if gc.E2EConfig == nil {
-		return errors.New("nil E2EConfig provided")
-	}
-
 	return nil
-}
-
-// E2EConfig is the configuration of the E2E tests.
-type E2EConfig struct {
-	// CustomRegistries is the contents of a yaml file which will be
-	// used as KUBE_TEST_REPO_LIST which overrides which registries
-	// e2e tests use.
-	CustomRegistries string
 }
 
 // RunConfig are the input options for running Sonobuoy.
@@ -116,12 +107,6 @@ type RunConfig struct {
 
 // Validate checks the config to determine if it is valid.
 func (rc *RunConfig) Validate() error {
-	// If given a manifest, just load it as-is.
-	if len(rc.GenFile) == 0 {
-		err := rc.GenConfig.Validate()
-		return errors.Wrap(err, "GenConfig validation failed")
-	}
-
 	return nil
 }
 

--- a/pkg/client/interfaces_test.go
+++ b/pkg/client/interfaces_test.go
@@ -50,34 +50,6 @@ func TestConfigValidation(t *testing.T) {
 			valid:  true,
 		},
 		{
-			desc:          "gen config without E2E config is not valid",
-			config:        &GenConfig{},
-			valid:         false,
-			expectedError: "nil E2EConfig provided",
-		},
-		{
-			desc: "gen config with E2E config is valid",
-			config: &GenConfig{
-				E2EConfig: &E2EConfig{},
-			},
-			valid: true,
-		},
-		{
-			desc:          "run config with invalid gen config is not valid",
-			config:        &RunConfig{},
-			valid:         false,
-			expectedError: "GenConfig validation failed: nil E2EConfig provided",
-		},
-		{
-			desc: "run config with valid gen config is valid",
-			config: &RunConfig{
-				GenConfig: GenConfig{
-					E2EConfig: &E2EConfig{},
-				},
-			},
-			valid: true,
-		},
-		{
 			desc:          "delete config with no namespace is not valid",
 			config:        &DeleteConfig{},
 			valid:         false,

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -165,9 +165,6 @@ func (c *SonobuoyClient) Run(cfg *RunConfig) error {
 			return errors.Wrap(err, "loading manifest")
 		}
 	} else {
-		if err := cfg.Validate(); err != nil {
-			return errors.Wrap(err, "config validation failed")
-		}
 		manifest, err = c.GenerateManifest(&cfg.GenConfig)
 		if err != nil {
 			return errors.Wrap(err, "couldn't run invalid manifest")

--- a/pkg/client/run_test.go
+++ b/pkg/client/run_test.go
@@ -34,11 +34,6 @@ func TestRunInvalidConfig(t *testing.T) {
 			expectedErrorMsg: "nil RunConfig provided",
 		},
 		{
-			desc:             "Passing an invalid config results in an error",
-			config:           &RunConfig{},
-			expectedErrorMsg: "config validation failed",
-		},
-		{
 			desc: "Passing a file takes priority over config flags",
 			config: &RunConfig{
 				GenFile: "foo.yaml",


### PR DESCRIPTION
In an effort to generalize some features to more than just e2e,
I implemented a way to tie command line flags directly to plugins
which may be loaded at a later time.

In this case, we use the transformation logic along with the new
configmap handling for plugins to add a config map and env var
to the e2e plugin whenever the user provides the flag for a custom
e2e repo configuration.
