### PR TITLE
Rework the gen plugin commands in order to reuse more code

### DIFF
--- a/test/integration/testdata/gen-plugin-e2e-configmap.golden
+++ b/test/integration/testdata/gen-plugin-e2e-configmap.golden
@@ -1,7 +1,3 @@
-config-map:
-  tiny-configmap.yaml: |
-    a: 1
-    b: 2
 podSpec:
   containers: []
   nodeSelector:
@@ -24,16 +20,18 @@ spec:
   command:
   - /run_e2e.sh
   env:
-  - name: E2E_FOCUS
-    value: \[Conformance\]
-  - name: E2E_SKIP
-    value: \[Disruptive\]|NoExecuteTaintManager
-  - name: E2E_PARALLEL
-    value: "false"
-  - name: E2E_USE_GO_RUNNER
-    value: "true"
   - name: E2E_EXTRA_ARGS
     value: --progress-report-url=http://localhost:8099/progress
+  - name: E2E_FOCUS
+    value: \[Conformance\]
+  - name: E2E_PARALLEL
+    value: "false"
+  - name: E2E_SKIP
+    value: \[Disruptive\]|NoExecuteTaintManager
+  - name: E2E_USE_GO_RUNNER
+    value: "true"
+  - name: SONOBUOY_K8S_VERSION
+    value: v123.456.789
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
@@ -41,4 +39,3 @@ spec:
   volumeMounts:
   - mountPath: /tmp/results
     name: results
-

--- a/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
+++ b/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
@@ -21,16 +21,18 @@ spec:
   command:
   - /run_e2e.sh
   env:
-  - name: E2E_FOCUS
-    value: \[Conformance\]
-  - name: E2E_SKIP
-    value: \[Disruptive\]|NoExecuteTaintManager
-  - name: E2E_PARALLEL
-    value: "false"
-  - name: E2E_USE_GO_RUNNER
-    value: "true"
   - name: E2E_EXTRA_ARGS
     value: --progress-report-url=http://localhost:8099/progress
+  - name: E2E_FOCUS
+    value: \[Conformance\]
+  - name: E2E_PARALLEL
+    value: "false"
+  - name: E2E_SKIP
+    value: \[Disruptive\]|NoExecuteTaintManager
+  - name: E2E_USE_GO_RUNNER
+    value: "true"
+  - name: SONOBUOY_K8S_VERSION
+    value: v123.456.789
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
@@ -38,4 +40,3 @@ spec:
   volumeMounts:
   - mountPath: /tmp/results
     name: results
-

--- a/test/integration/testdata/gen-plugin-e2e.golden
+++ b/test/integration/testdata/gen-plugin-e2e.golden
@@ -20,16 +20,18 @@ spec:
   command:
   - /run_e2e.sh
   env:
-  - name: E2E_FOCUS
-    value: \[Conformance\]
-  - name: E2E_SKIP
-    value: \[Disruptive\]|NoExecuteTaintManager
-  - name: E2E_PARALLEL
-    value: "false"
-  - name: E2E_USE_GO_RUNNER
-    value: "true"
   - name: E2E_EXTRA_ARGS
     value: --progress-report-url=http://localhost:8099/progress
+  - name: E2E_FOCUS
+    value: \[Conformance\]
+  - name: E2E_PARALLEL
+    value: "false"
+  - name: E2E_SKIP
+    value: \[Disruptive\]|NoExecuteTaintManager
+  - name: E2E_USE_GO_RUNNER
+    value: "true"
+  - name: SONOBUOY_K8S_VERSION
+    value: v123.456.789
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
@@ -37,4 +39,3 @@ spec:
   volumeMounts:
   - mountPath: /tmp/results
     name: results
-


### PR DESCRIPTION
- Adds a new method that allows us to easily reuse all the `gen`
logic and then just pull out the plugin we want.
- Removes the ability to specify configmaps to gen plugin e2e;
this seems like a trivial loss since I just added it in order
to achieve some other goal related to the windows plugins and
it never filled much of a real need.

This PR is meant to precede another related to how the k8s-version
flags are handled. In that PR, it broke the `gen plugin e2e` command
since this command wasn't really processing the plugin in the
same way that `gen` would.

**Release note**:
```
Removed the ability to specify configmaps to `gen plugin e2e`. That was a very recent addition, had no obvious benefit, and was counter to the general intent of the `gen plugin e2e` command which was to present you with the e2e plugin that `gen` would have
```
