### PR TITLE
Apply ImagePullPolicy to all plugins not just built-in

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -131,6 +131,12 @@ func (*SonobuoyClient) GenerateManifestAndPlugins(cfg *GenConfig) ([]byte, []*ma
 		return strings.ToLower(plugins[i].SonobuoyConfig.PluginName) < strings.ToLower(plugins[j].SonobuoyConfig.PluginName)
 	})
 
+	// Apply our universal transforms; only applies to ImagePullPolicy. Overrides all
+	// plugin values.
+	for _, p := range plugins {
+		p.Spec.ImagePullPolicy = corev1.PullPolicy(conf.ImagePullPolicy)
+	}
+
 	// Apply transforms. Ensure this is before handling configmaps and applying the k8s_version.
 	for pluginName, transforms := range cfg.PluginTransforms {
 		for _, p := range plugins {

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -403,6 +403,22 @@ func TestGenerateManifestGolden(t *testing.T) {
 				},
 			},
 			goldenFile: filepath.Join("testdata", "plugin-configmaps.golden"),
+		}, {
+			name: "ImagePullPolicy applied to all plugins",
+			inputcm: &client.GenConfig{
+				Config:      staticConfig(),
+				KubeVersion: "v99+static.testing",
+				StaticPlugins: []*manifest.Manifest{
+					{
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin1"},
+						Spec:           manifest.Container{Container: v1.Container{ImagePullPolicy: "Never"}},
+					}, {
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin2"},
+						Spec:           manifest.Container{Container: v1.Container{ImagePullPolicy: "Always"}},
+					},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "imagePullPolicy-all-plugins.golden"),
 		},
 	}
 

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/imagePullPolicy-all-plugins.golden
+++ b/pkg/client/testdata/imagePullPolicy-all-plugins.golden
@@ -15,7 +15,7 @@ metadata:
 apiVersion: v1
 data:
   config.json: |
-    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":[{"name":"a"}],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
+    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
 kind: ConfigMap
 metadata:
   labels:
@@ -28,7 +28,7 @@ data:
   plugin-0.yaml: |
     sonobuoy-config:
       driver: ""
-      plugin-name: a
+      plugin-name: myplugin1
     spec:
       env:
       - name: SONOBUOY_K8S_VERSION
@@ -39,7 +39,7 @@ data:
   plugin-1.yaml: |
     sonobuoy-config:
       driver: ""
-      plugin-name: b
+      plugin-name: myplugin2
     spec:
       env:
       - name: SONOBUOY_K8S_VERSION

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/plugin-configmaps.golden
+++ b/pkg/client/testdata/plugin-configmaps.golden
@@ -40,6 +40,7 @@ data:
       env:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: ""
       resources: {}
       volumeMounts:
@@ -60,6 +61,7 @@ data:
       env:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: ""
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -58,6 +58,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: k8s.gcr.io/conformance:v99+static.testing
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -86,6 +87,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
       image: sonobuoy/systemd-logs:v0.3
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -74,6 +74,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
       image: hello:v9
+      imagePullPolicy: IfNotPresent
       name: plugin
       resources: {}
       volumeMounts:
@@ -91,6 +92,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
       image: hello:v123.456.789
+      imagePullPolicy: IfNotPresent
       name: plugin
       resources: {}
       volumeMounts:


### PR DESCRIPTION
Previously we applied imagePullPolicy to just the built in
plugins. This allowed users to specify the policy for each
plugin but made it inconvenient to change (had to manually
change the YAML) and inconsistent between our built-in
and custom plugins.

This applies the imagePullPolicy from the config to every
plugin. It occurs prior to the other plugin transformations
from flags, so if we do add something like a per-plugin
imagePullPolicy, it wouldn't interfere. I don't there will
be much demand for that though.

Signed-off-by: John Schnake <jschnake@vmware.com>

Related to #1315 

**Release note**:
```
ImagePullPolicy will now be applied to all plugins run by Sonobuoy, not just our built-in e2e and systemd-logs plugins.
```
