### PR TITLE
Add new fields to plugin manifests

### DIFF
--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -242,6 +242,14 @@ func (cp *MockCleanupPlugin) GetResultFiles() []string {
 	return []string{}
 }
 
+func (cp *MockCleanupPlugin) GetDescription() string {
+	return "A mock plugin used for testing purposes"
+}
+
+func (cp *MockCleanupPlugin) GetSourceURL() string {
+	return ""
+}
+
 func TestCleanup(t *testing.T) {
 	createPlugin := func(skipCleanup bool) *MockCleanupPlugin {
 		return &MockCleanupPlugin{

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -78,6 +78,16 @@ func (b *Base) GetResultFiles() []string {
 	return b.Definition.SonobuoyConfig.ResultFiles
 }
 
+// GetSourceURL returns the sourceURL of the plugin.
+func (b *Base) GetSourceURL() string {
+	return b.Definition.SonobuoyConfig.SourceURL
+}
+
+// GetDescription returns the human-readable plugin description.
+func (b *Base) GetDescription() string {
+	return b.Definition.SonobuoyConfig.Description
+}
+
 // MakeTLSSecret makes a Kubernetes secret object for the given TLS certificate.
 func (b *Base) MakeTLSSecret(cert *tls.Certificate, ownerPod *v1.Pod) (*v1.Secret, error) {
 	rsaKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -40,27 +40,40 @@ type Interface interface {
 	// Run runs a plugin, declaring all resources it needs, and then
 	// returns.  It does not block and wait until the plugin has finished.
 	Run(kubeClient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort string) error
+
 	// Cleanup cleans up all resources created by the plugin
 	Cleanup(kubeClient kubernetes.Interface)
+
 	// Monitor continually checks for problems in the resources created by a
 	// plugin (either because it won't schedule, or the image won't
 	// download, too many failed executions, etc) and sends the errors as
 	// Result objects through the provided channel. It should return once the context
 	// is cancelled.
 	Monitor(ctx context.Context, kubeClient kubernetes.Interface, availableNodes []v1.Node, resultsCh chan<- *Result)
+
 	// ExpectedResults is an array of Result objects that a plugin should
 	// expect to submit.
 	ExpectedResults(nodes []v1.Node) []ExpectedResult
+
 	// GetName returns the name of this plugin
 	GetName() string
+
 	// SkipCleanup returns whether cleanup for this plugin should be skipped or not.
 	SkipCleanup() bool
+
 	// GetResultFormat states the type of results this plugin generates and facilates post-processing
 	// those results.
 	GetResultFormat() string
+
 	// GetResultFiles returns the specific files to target for post-processing. If empty, each
 	// result format specifies its own heuristic for determining those files.
 	GetResultFiles() []string
+
+	// GetDescription returns the human-readable description of the plugin.
+	GetDescription() string
+
+	// GetSourceURL returns the URL where the plugin came from and where updates to it will be located.
+	GetSourceURL() string
 }
 
 // ExpectedResult is an expected result that a plugin will submit.  This is so

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -43,6 +43,13 @@ type SonobuoyConfig struct {
 	// to avoid automatically targeting other files or failing to target this one due to heuristics.
 	ResultFiles []string `json:"result-files,omitempty"`
 
+	// Description is an optional, human-readable description for the plugin.
+	Description string `json:"description,omitempty"`
+
+	// SourceURL is an optional URL which describes the source of the plugin and where updates
+	// to the plugin source would be kept.
+	SourceURL string `json:"source-url,omitempty"`
+
 	objectKind
 }
 


### PR DESCRIPTION
Adding description and sourceURL in order to
facilitate the plugin management.

Related to #1292

**Release note**:
```
Plugins may now specify `sourceURL` and `description` fields in the `sonobuoy-config` of their plugin so that they are more self-documenting.
```
