### PR TITLE
Fix issue with custom log levels

### DIFF
--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -63,7 +63,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdSplat())
 
 	initKlog(cmds)
-	cmds.PersistentFlags().StringVar(&errlog.LogLevel, "level", "info", "Log level. One of {panic, fatal, error, warn, info, debug, trace}")
+	cmds.PersistentFlags().Var(&errlog.LogLevel, "level", "Log level. One of {panic, fatal, error, warn, info, debug, trace}")
 
 	// Previously just had debug flag but in desire to have fine grained control over output we opted to
 	// have full ability to set level instead.

--- a/pkg/errlog/errlog.go
+++ b/pkg/errlog/errlog.go
@@ -27,16 +27,25 @@ var (
 	DebugOutput = false
 
 	// loglevel used for sirupsen/logrus
-	LogLevel = "info"
+	LogLevel logLevelFlagType = "info"
 )
 
-func SetLevel() {
+type logLevelFlagType string
+
+func (l *logLevelFlagType) String() string { return string(*l) }
+func (l *logLevelFlagType) Type() string   { return "level" }
+func (l *logLevelFlagType) Set(str string) error {
+	*l = logLevelFlagType(str)
+	return SetLevel(str)
+}
+
+func SetLevel(s string) error {
 	// Just using debug to set log level for as long
 	// as we want to keep the deprecated flag.
 	if DebugOutput {
 		LogLevel = "debug"
 	}
-	switch LogLevel {
+	switch s {
 	case "panic":
 		logrus.SetLevel(logrus.PanicLevel)
 	case "fatal":
@@ -54,10 +63,11 @@ func SetLevel() {
 		logrus.SetLevel(logrus.TraceLevel)
 		DebugOutput = true
 	default:
-		logrus.Warningf("Unknown log level %q. Defaulting to info.", LogLevel)
-		LogLevel = "info"
-		logrus.SetLevel(logrus.InfoLevel)
+		return fmt.Errorf("unknown log level %q", s)
 	}
+
+	return nil
+
 }
 
 // LogError logs an error, optionally with a tracelog


### PR DESCRIPTION
Previous implementation for custom log levels failed since it
used a string flag which never actually called the method
doing the logrus configuration.

Now we use a custom flag type which will call our own 'set' method
and has been demonstrated to work correctly.

Fixes #1189

Signed-off-by: John Schnake <jschnake@vmware.com>