### PR TITLE
Adds plugin installation functionality

### DIFF
--- a/cmd/sonobuoy/app/pluginCache.go
+++ b/cmd/sonobuoy/app/pluginCache.go
@@ -1,0 +1,272 @@
+/*
+Copyright the Sonobuoy contributors 2021
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/loader"
+	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	SonobuoyDirEnvKey = "SONOBUOY_DIR"
+)
+
+var (
+	defaultSonobuoyDir = filepath.Join("~", ".sonobuoy")
+)
+
+func NewCmdPlugin() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "plugin",
+		Aliases: []string{"plugins"},
+		Short:   "Manage your installed plugins",
+		Hidden:  true,
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all installed plugins",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listInstalledPlugins(getPluginCacheLocation(cmd))
+		},
+	}
+
+	showCmd := &cobra.Command{
+		Use:   "show <plugin filename>",
+		Short: "Print the full definition of the named plugin file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showInstalledPlugin(getPluginCacheLocation(cmd), filenameFromArg(args[0], ".yaml"))
+		},
+	}
+
+	installCmd := &cobra.Command{
+		Use:   "install <save-as-filename> <source filename or URL>",
+		Short: "Install a plugin so that it can be run via just its filename rather than a full path or URL.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return installPlugin(getPluginCacheLocation(cmd), filenameFromArg(args[0], ".yaml"), args[1])
+		},
+	}
+
+	uninstallCmd := &cobra.Command{
+		Use:   "uninstall <plugin filename>",
+		Short: "Uninstall a plugin. You can continue to run any plugin via specifying a file or URL.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return uninstallPlugin(getPluginCacheLocation(cmd), filenameFromArg(args[0], ".yaml"))
+		},
+	}
+
+	cmd.AddCommand(listCmd, showCmd, installCmd, uninstallCmd)
+
+	return cmd
+}
+
+// getPluginCacheLocation will return the location of the plugin cache (defaults to ~/.sonobuoy)
+// If no override is set in the env, the default is assumed. If we are unable to expand to an abosolute
+// path then we return the empty string signalling the feature should be disabled.
+func getPluginCacheLocation(cmd *cobra.Command) string {
+	usePath := os.Getenv(SonobuoyDirEnvKey)
+	if len(usePath) == 0 {
+		usePath = defaultSonobuoyDir
+	}
+	expandedPath, err := expandPath(usePath)
+	if err != nil {
+		logrus.Errorf("failed to expand sonobuoy directory %q: %v", usePath, err)
+		return ""
+	}
+
+	if _, err := os.Stat(expandedPath); err != nil && os.IsNotExist(err) {
+		logrus.Debugf("sonobuoy plugin location %q does not exist, creating it.", expandedPath)
+		if err := os.Mkdir(expandedPath, 0777); err != nil {
+			logrus.Errorf("failed to create directory for installed plugins %q: %v", expandedPath, err)
+			return ""
+		}
+	}
+
+	logrus.Debugf("Using plugin cache location %q", expandedPath)
+	return expandedPath
+}
+
+func listInstalledPlugins(installedDir string) error {
+	if len(installedDir) == 0 {
+		return errors.New("unable to list plugins; installation directory unavailable")
+	}
+
+	pluginFiles, _ := loadPlugins(installedDir)
+
+	prefix := ""
+	first := true
+	for filename, p := range pluginFiles {
+		if !first {
+			prefix = "---\n"
+		}
+		fmt.Printf("%vfilename: %v\nplugin name: %v\nsource URL: %v\ndescription: %v\n",
+			prefix, filename, p.SonobuoyConfig.PluginName, p.SonobuoyConfig.SourceURL, p.SonobuoyConfig.Description)
+		first = false
+	}
+
+	return nil
+}
+
+// loadPlugins loads all plugins from the given directory (recursively) and
+// returns a map of their filename and contents. Returns the first error encountered
+// but continues to load and return as many plugins as possible. All errors are logged.
+// The resulting map, therefore, can be used even if an error is returned.
+func loadPlugins(installedDir string) (map[string]*manifest.Manifest, error) {
+	pluginMap := map[string]*manifest.Manifest{}
+	var firstErr error
+
+	err := filepath.Walk(installedDir, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
+			m, err := loader.LoadDefinitionFromFile(path)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				logrus.Error(errors.Wrapf(err, "failed to load definition from file %q", path))
+				return nil
+			}
+			pluginMap[path] = m
+		}
+		return nil
+	})
+	if err != nil {
+		if firstErr == nil {
+			firstErr = err
+		}
+		logrus.Errorf("error walking the path %q: %v\n", installedDir, err)
+	}
+
+	return pluginMap, firstErr
+}
+
+func loadPlugin(installedDir, reqFile string) (*manifest.Manifest, error) {
+	// Ignore error since it may not have to do with this plugin at all. Only return error if not found.
+	// The loadPlugins will log errors as needed for visibility anyways.
+	manMap, _ := loadPlugins(installedDir)
+	reqManifest := manMap[filepath.Join(installedDir, reqFile)]
+	if reqManifest != nil {
+		return reqManifest, nil
+	}
+	return nil, fmt.Errorf("failed to find plugin file %v within directory %v", reqFile, installedDir)
+}
+
+// filenameFromArg will ensure the arg has the extension requested. This allows
+// users to provide `-p foo` while loading the plugin file `foo.yaml`.
+func filenameFromArg(arg, extension string) string {
+	if filepath.Ext(arg) != extension {
+		return fmt.Sprintf("%v%v", arg, extension)
+	}
+	return arg
+}
+
+// showInstalledPlugin returns the YAML of the plugin specified in the given file relative
+// to the given installation directory.
+func showInstalledPlugin(installedDir, reqPluginFile string) error {
+	if len(installedDir) == 0 {
+		return errors.New("unable to show plugin; installation directory unavailable")
+	}
+
+	plugin, err := loadPlugin(installedDir, reqPluginFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to load installed plugins")
+	}
+
+	yaml, err := kuberuntime.Encode(manifest.Encoder, plugin)
+	if err != nil {
+		return errors.Wrap(err, "serializing as YAML")
+	}
+	fmt.Println(string(yaml))
+	return nil
+}
+
+// installPlugin will read the plugin at src (URL or file) then install it into the
+// installation directory with the given filename. If too many or too few plugins
+// are loaded, errors are returned. The returned string is a human-readable description
+// of the action taken.
+func installPlugin(installedDir, filename, src string) error {
+	if len(installedDir) == 0 {
+		return errors.New("unable to install plugins; installation directory unavailable")
+	}
+
+	newPath := filepath.Join(installedDir, filename)
+	var pl pluginList
+	if err := pl.Set(src); err != nil {
+		return err
+	}
+
+	if len(pl.StaticPlugins) > 1 {
+		return fmt.Errorf("may only install one plugin at a time, found %v", len(pl.StaticPlugins))
+	}
+	if len(pl.StaticPlugins) < 1 {
+		return fmt.Errorf("expected 1 plugin, found %v", len(pl.StaticPlugins))
+	}
+
+	yaml, err := kuberuntime.Encode(manifest.Encoder, pl.StaticPlugins[0])
+	if err != nil {
+		return errors.Wrap(err, "failed to encode plugin")
+	}
+	if err := os.WriteFile(newPath, yaml, 0666); err != nil {
+		return err
+	}
+	fmt.Printf("Installed plugin %v into file %v from source %v\n", pl.StaticPlugins[0].Spec.Name, newPath, src)
+	return nil
+}
+
+func uninstallPlugin(installedDir, filename string) error {
+	if len(installedDir) == 0 {
+		return errors.New("unable to uninstall plugins; installation directory unavailable")
+	}
+
+	pluginPath := filepath.Join(installedDir, filename)
+
+	_, err := loadPlugin(installedDir, filename)
+	if err != nil {
+		return errors.Wrap(err, "failed to load installed plugins")
+	}
+
+	if err := os.Remove(pluginPath); err != nil {
+		return errors.Wrapf(err, "failed to uninstall plugin file %v", pluginPath)
+	}
+
+	fmt.Printf("Uninstalled plugin file %v\n", pluginPath)
+	return nil
+}
+
+func expandPath(path string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	if len(path) > 0 && path[0] == '~' {
+		path = filepath.Join(home, path[1:])
+	}
+	return path, nil
+}

--- a/cmd/sonobuoy/app/pluginCache_test.go
+++ b/cmd/sonobuoy/app/pluginCache_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright the Sonobuoy contributors 2021
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestFilenameFromArg(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "Adds ext",
+			input:    "in",
+			expected: "in.yaml",
+		}, {
+			desc:     "Accepts ext already present",
+			input:    "in.yaml",
+			expected: "in.yaml",
+		}, {
+			desc:     "Only looks at last extension",
+			input:    "in.ext1.ext2.yaml",
+			expected: "in.ext1.ext2.yaml",
+		}, {
+			desc:     "Only looks at last extension",
+			input:    "in.ext1.ext2",
+			expected: "in.ext1.ext2.yaml",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			o := filenameFromArg(tc.input, ".yaml")
+			if o != tc.expected {
+				t.Errorf("Expected %v but got %v", tc.expected, o)
+			}
+		})
+	}
+}
+
+func TestGetPluginCacheLocation(t *testing.T) {
+	defaultDir, err := expandPath(defaultSonobuoyDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tcs := []struct {
+		desc     string
+		input    string
+		expected string
+		cleanup  bool
+	}{
+		{
+			desc:     "Defaults to home directory and resolves",
+			input:    "",
+			expected: defaultDir,
+		}, {
+			desc:     "Override from env",
+			input:    "./testdata/foo",
+			expected: "./testdata/foo",
+			cleanup:  true,
+		}, {
+			desc:     "Bad dir means empty result",
+			input:    "~~~~/testdata",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		origval := os.Getenv(SonobuoyDirEnvKey)
+		defer os.Setenv(SonobuoyDirEnvKey, origval)
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.cleanup {
+				defer os.RemoveAll(tc.input)
+			}
+			cmd := &cobra.Command{}
+			os.Setenv(SonobuoyDirEnvKey, tc.input)
+			o := getPluginCacheLocation(cmd)
+			if o != tc.expected {
+				t.Errorf("Expected %v but got %v", tc.expected, o)
+			}
+		})
+	}
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -62,6 +62,8 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdResults())
 	cmds.AddCommand(NewCmdSplat())
 
+	cmds.AddCommand(NewCmdPlugin())
+
 	initKlog(cmds)
 	cmds.PersistentFlags().Var(&errlog.LogLevel, "level", "Log level. One of {panic, fatal, error, warn, info, debug, trace}")
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gophercloud/gophercloud v0.2.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-version v1.2.0
-	github.com/imdario/mergo v0.3.7
+	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/magiconair/properties v1.8.1 // indirect

--- a/pkg/plugin/loader/loader_test.go
+++ b/pkg/plugin/loader/loader_test.go
@@ -50,7 +50,7 @@ func TestFindPlugins(t *testing.T) {
 }
 
 func TestLoadNonexistentPlugin(t *testing.T) {
-	_, err := loadDefinitionFromFile("non/existent/path")
+	_, err := LoadDefinitionFromFile("non/existent/path")
 	if errors.Cause(err).Error() != "open non/existent/path: no such file or directory" {
 		t.Errorf("Expected ErrNotExist, got %v", errors.Cause(err))
 	}
@@ -58,14 +58,9 @@ func TestLoadNonexistentPlugin(t *testing.T) {
 
 func TestLoadValidPlugin(t *testing.T) {
 	jobDefFileName := "testdata/plugin.d/job.yml"
-	jobDefFile, err := loadDefinitionFromFile(jobDefFileName)
+	jobDef, err := LoadDefinitionFromFile(jobDefFileName)
 	if err != nil {
 		t.Fatalf("Unexpected error reading job plugin: %v", err)
-	}
-
-	jobDef, err := loadDefinition(jobDefFile)
-	if err != nil {
-		t.Fatalf("Unexpected error loading job plugin: %v", err)
 	}
 
 	if jobDef.SonobuoyConfig.Driver != "Job" {
@@ -80,13 +75,9 @@ func TestLoadValidPlugin(t *testing.T) {
 	}
 
 	daemonDefFileName := "testdata/plugin.d/daemonset.yaml"
-	daemonDefFile, err := loadDefinitionFromFile(daemonDefFileName)
+	daemonDef, err := LoadDefinitionFromFile(daemonDefFileName)
 	if err != nil {
 		t.Fatalf("Unexpected error creating daemonset plugin: %v", err)
-	}
-	daemonDef, err := loadDefinition(daemonDefFile)
-	if err != nil {
-		t.Fatalf("Unexpected error loading daemonset plugin: %v", err)
 	}
 
 	if daemonDef.SonobuoyConfig.Driver != "DaemonSet" {
@@ -125,14 +116,9 @@ func TestLoadValidPluginWithSkipCleanup(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			jobDefFile, err := loadDefinitionFromFile(tc.jobDefFileName)
+			jobDef, err := LoadDefinitionFromFile(tc.jobDefFileName)
 			if err != nil {
 				t.Fatalf("Unexpected error reading job plugin: %v", err)
-			}
-
-			jobDef, err := loadDefinition(jobDefFile)
-			if err != nil {
-				t.Fatalf("Unexpected error loading job plugin: %v", err)
 			}
 
 			if jobDef.SonobuoyConfig.SkipCleanup != tc.expectedValue {

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -345,6 +345,6 @@ update_local() {
     # Ensure you build using the intended script so buildinfo gets set.
     native
     # Integration tests take longer and need kind (usually). Just run the test we need.
-    go test $GOTARGET/test/integration -update -v -tags integration -run TestExactOutput
+    go test $GOTARGET/test/integration -update -v -tags integration -run 'Golden'
     set +x
 }

--- a/test/integration/testdata/plugin-delete-not-found.golden
+++ b/test/integration/testdata/plugin-delete-not-found.golden
@@ -1,0 +1,11 @@
+Error: failed to load installed plugins: failed to find plugin file foo.yaml within directory *STATIC_FOR_TESTING*
+Usage:
+  sonobuoy plugin uninstall <plugin filename> [flags]
+
+Flags:
+  -h, --help   help for uninstall
+
+Global Flags:
+      --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)
+
+time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load installed plugins: failed to find plugin file foo.yaml within directory *STATIC_FOR_TESTING*"

--- a/test/integration/testdata/plugin-install-delete.golden
+++ b/test/integration/testdata/plugin-install-delete.golden
@@ -1,0 +1,16 @@
+Installed plugin plugin into file *STATIC_FOR_TESTING*/foo.yaml from source ./testdata/plugins/good/hello-world.yaml
+Installed plugin plugin into file *STATIC_FOR_TESTING*/foo2.yaml from source ./testdata/plugins/good/hello-world.yaml
+filename: *STATIC_FOR_TESTING*/foo.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.
+---
+filename: *STATIC_FOR_TESTING*/foo2.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.
+Uninstalled plugin file *STATIC_FOR_TESTING*/foo.yaml
+filename: *STATIC_FOR_TESTING*/foo2.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.

--- a/test/integration/testdata/plugin-install.golden
+++ b/test/integration/testdata/plugin-install.golden
@@ -1,0 +1,5 @@
+Installed plugin plugin into file *STATIC_FOR_TESTING*/foo.yaml from source ./testdata/plugins/good/hello-world.yaml
+filename: *STATIC_FOR_TESTING*/foo.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.

--- a/test/integration/testdata/plugin-list-good-bad.golden
+++ b/test/integration/testdata/plugin-list-good-bad.golden
@@ -1,0 +1,21 @@
+time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p2.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p2.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
+time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p4.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p4.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
+Installed plugin plugin into file *STATIC_FOR_TESTING*/p1.yaml from source ./testdata/plugins/good/hello-world.yaml
+Installed plugin plugin into file *STATIC_FOR_TESTING*/p3.yaml from source ./testdata/plugins/good/hello-world.yaml
+Installed plugin plugin into file *STATIC_FOR_TESTING*/p5.yaml from source ./testdata/plugins/good/hello-world.yaml
+time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p2.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p2.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
+time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p4.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p4.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
+filename: *STATIC_FOR_TESTING*/p1.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.
+---
+filename: *STATIC_FOR_TESTING*/p3.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.
+---
+filename: *STATIC_FOR_TESTING*/p5.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.

--- a/test/integration/testdata/plugin-list.golden
+++ b/test/integration/testdata/plugin-list.golden
@@ -1,0 +1,9 @@
+filename: testdata/plugins/good/hello-world.yaml
+plugin name: hello-world
+source URL: foo.com
+description: This is a plugin description.
+---
+filename: testdata/plugins/good/hw-2.yaml
+plugin name: hello-world2
+source URL: 
+description: 

--- a/test/integration/testdata/plugin-show-2.golden
+++ b/test/integration/testdata/plugin-show-2.golden
@@ -1,0 +1,14 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: hello-world2
+  result-format: raw
+spec:
+  command:
+  - ./run.sh
+  image: hello:v9
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+

--- a/test/integration/testdata/plugin-show-not-found.golden
+++ b/test/integration/testdata/plugin-show-not-found.golden
@@ -1,0 +1,10 @@
+Error: failed to load installed plugins: failed to find plugin file no-plugin.yaml within directory testdata/plugins/good
+Usage:
+  sonobuoy plugin show <plugin filename> [flags]
+
+Flags:
+  -h, --help   help for show
+
+Global Flags:
+      --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)
+

--- a/test/integration/testdata/plugin-show-w-ext.golden
+++ b/test/integration/testdata/plugin-show-w-ext.golden
@@ -1,0 +1,16 @@
+sonobuoy-config:
+  description: This is a plugin description.
+  driver: Job
+  plugin-name: hello-world
+  result-format: raw
+  source-url: foo.com
+spec:
+  command:
+  - ./run.sh
+  image: hello:v9
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+

--- a/test/integration/testdata/plugin-show-wo-ext.golden
+++ b/test/integration/testdata/plugin-show-wo-ext.golden
@@ -1,0 +1,16 @@
+sonobuoy-config:
+  description: This is a plugin description.
+  driver: Job
+  plugin-name: hello-world
+  result-format: raw
+  source-url: foo.com
+spec:
+  command:
+  - ./run.sh
+  image: hello:v9
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+

--- a/test/integration/testdata/plugins/bad-plugin.yaml
+++ b/test/integration/testdata/plugins/bad-plugin.yaml
@@ -1,0 +1,1 @@
+sonobuoy-config: bad

--- a/test/integration/testdata/plugins/good/hello-world.yaml
+++ b/test/integration/testdata/plugins/good/hello-world.yaml
@@ -1,0 +1,15 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: hello-world
+  result-format: raw
+  source-url: foo.com
+  description: This is a plugin description.
+spec:
+  command:
+  - ./run.sh
+  image: hello:v9
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results

--- a/test/integration/testdata/plugins/good/hw-2.yaml
+++ b/test/integration/testdata/plugins/good/hw-2.yaml
@@ -1,0 +1,13 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: hello-world2
+  result-format: raw
+spec:
+  command:
+  - ./run.sh
+  image: hello:v9
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results


### PR DESCRIPTION
Adds a known location, ~/.sonobuoy or SONOBUOY_DIR env,
which stores plugin files (*.yaml). When running plugins this location is searched
first so that users can more easily call custom plugins from any location.

Adds:
 - plugins list command
 - plugin show command
 - plugin install command
 - plugin uninstall command
 - tests for the above

Partially fixes: #1292
Signed-off-by: John Schnake <jschnake@vmware.com>