### PR TITLE
pkg/tarball: fix dropped test error

### DIFF
--- a/pkg/tarball/tarball_test.go
+++ b/pkg/tarball/tarball_test.go
@@ -93,6 +93,9 @@ func TestDecodeTarball(t *testing.T) {
 		Typeflag: tar.TypeSymlink,
 		ModTime:  time.Now(),
 	})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
 
 	err = w.Close()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

**What this PR does / why we need it**:
This fixes a dropped test error.


**Release note**:
```
release-note NONE
```
