### PR TITLE
pkg/plugin/driver/utils: fix multiple imports

### DIFF
--- a/pkg/plugin/driver/utils/utils_test.go
+++ b/pkg/plugin/driver/utils/utils_test.go
@@ -21,20 +21,19 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPodFailing(t *testing.T) {
 	// fromGoodPod is a helper function to simplify the specification of test cases.
 	fromGoodPod := func(f func(*corev1.Pod) *corev1.Pod) *corev1.Pod {
-		goodPod := &v1.Pod{}
+		goodPod := &corev1.Pod{}
 		return f(goodPod)
 	}
 
 	testCases := []struct {
 		desc          string
-		pod           *v1.Pod
+		pod           *corev1.Pod
 		expectFailing bool
 		expectMsg     string
 	}{


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

This fixes multiple imports of `k8s.io/api/core/v1` in `pkg/plugin/driver/utils`.

**Release note**:
```
NONE
```
