### PR TITLE
Add progress output and feature gate it as default

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -316,7 +316,7 @@ func AddWaitOutputFlag(mode *WaitOutputMode, flags *pflag.FlagSet, defaultMode W
 	*mode = defaultMode
 	flags.Var(
 		mode, waitOutputFlag,
-		"Whether to enable spinner on Sonobuoy. Valid modes are Silent and Spinner")
+		"Specify the type of output Sonobuoy should produce when --wait is used. Valid modes are silent, spinner, or progress")
 }
 
 // AddImagePullPolicyFlag adds a boolean flag for deleting everything (including E2E tests).

--- a/cmd/sonobuoy/app/delete.go
+++ b/cmd/sonobuoy/app/delete.go
@@ -49,8 +49,11 @@ func NewCmdDelete() *cobra.Command {
 	AddRBACModeFlags(&f.rbacMode, cmd.Flags(), DetectRBACMode)
 	AddDeleteAllFlag(&f.deleteAll, cmd.Flags())
 	AddDeleteWaitFlag(&f.wait, cmd.Flags())
-	AddWaitOutputFlag(&f.waitOutput, cmd.Flags(), SilentOutputMode)
-
+	if featureEnabled(FeatureWaitOutputProgressByDefault) {
+		AddWaitOutputFlag(&f.waitOutput, cmd.Flags(), ProgressOutputMode)
+	} else {
+		AddWaitOutputFlag(&f.waitOutput, cmd.Flags(), SilentOutputMode)
+	}
 	return cmd
 }
 

--- a/cmd/sonobuoy/app/featureGates.go
+++ b/cmd/sonobuoy/app/featureGates.go
@@ -3,8 +3,11 @@ package app
 import "os"
 
 const (
-	FeaturesAll               = "SONOBUOY_ALL_FEATURES"
+	FeaturesAll = "SONOBUOY_ALL_FEATURES"
+
 	FeaturePluginInstallation = "SONOBUOY_PLUGIN_INSTALLATION"
+
+	FeatureWaitOutputProgressByDefault = "SONOBUOY_PLUGIN_INSTALLATION"
 )
 
 func featureEnabled(feature string) bool {

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -47,7 +47,12 @@ func RunFlagSet(cfg *runFlags) *pflag.FlagSet {
 	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode))
 	AddSkipPreflightFlag(&cfg.skipPreflight, runset)
 	AddRunWaitFlag(&cfg.wait, runset)
-	AddWaitOutputFlag(&cfg.waitOutput, runset, SilentOutputMode)
+	if featureEnabled(FeatureWaitOutputProgressByDefault) {
+		AddWaitOutputFlag(&cfg.waitOutput, runset, ProgressOutputMode)
+	} else {
+		AddWaitOutputFlag(&cfg.waitOutput, runset, SilentOutputMode)
+	}
+
 	runset.StringVarP(
 		&cfg.genFile, "file", "f", "",
 		"If set, loads the file as if it were the output from sonobuoy gen. Set to `-` to read from stdin.",

--- a/cmd/sonobuoy/app/testdata/expectedShowAll.golden
+++ b/cmd/sonobuoy/app/testdata/expectedShowAll.golden
@@ -1,0 +1,7 @@
+         PLUGIN     NODE     STATUS   RESULT           PROGRESS
+            e2e   global   complete   failed   2/2 (1 failures)
+   systemd_logs   node01    running                            
+   systemd_logs   node02   complete   failed   2/3 (1 failures)
+   systemd_logs   node03    running                            
+
+Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.

--- a/cmd/sonobuoy/app/testdata/expectedSummary.golden
+++ b/cmd/sonobuoy/app/testdata/expectedSummary.golden
@@ -1,0 +1,6 @@
+         PLUGIN     STATUS   RESULT   COUNT           PROGRESS
+            e2e   complete   failed       1   2/2 (1 failures)
+   systemd_logs   complete   failed       1                   
+   systemd_logs    running                2                   
+
+Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.

--- a/cmd/sonobuoy/app/wait.go
+++ b/cmd/sonobuoy/app/wait.go
@@ -8,20 +8,22 @@ import (
 type WaitOutputMode string
 
 const (
-	SilentOutputMode  WaitOutputMode = "Silent"
-	SpinnerOutputMode WaitOutputMode = "Spinner"
+	SilentOutputMode   WaitOutputMode = "Silent"
+	SpinnerOutputMode  WaitOutputMode = "Spinner"
+	ProgressOutputMode WaitOutputMode = "Progress"
 )
 
 var waitOutputModeMap = map[string]WaitOutputMode{
-	string(SilentOutputMode):  SilentOutputMode,
-	string(SpinnerOutputMode): SpinnerOutputMode,
+	string(SilentOutputMode):   SilentOutputMode,
+	string(SpinnerOutputMode):  SpinnerOutputMode,
+	string(ProgressOutputMode): ProgressOutputMode,
 }
 
 // String needed for pflag.Value.
 func (w *WaitOutputMode) String() string { return string(*w) }
 
 // Type needed for pflag.Value.
-func (w *WaitOutputMode) Type() string { return "WaitOutputMode" }
+func (w *WaitOutputMode) Type() string { return "string" }
 
 // Set the WaitOutputMode to the given string, or error if it's not a known WaitOutputMode mode.
 func (w *WaitOutputMode) Set(str string) error {
@@ -29,7 +31,7 @@ func (w *WaitOutputMode) Set(str string) error {
 	upcase := strings.Title(str)
 	mode, ok := waitOutputModeMap[upcase]
 	if !ok {
-		return fmt.Errorf("unknown Wait Output mode %s", str)
+		return fmt.Errorf("unknown wait output mode %s", str)
 	}
 	*w = mode
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.18.5

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,9 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=


### PR DESCRIPTION
 - Adds new wait-output mode "Progress" which outputs
details of the progress as the methods poll for completion.
 - Modifies `sonobuoy status` to show progress if possible
 - Adds a featuregate for making this the default behavior. This
sort of output seems like it would be greatly appreciated and most
wont care about the verbosity.

Partially fixes: #1170

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Adds an experimental feature to show progress updates by default when using --wait flags instead of being silent. You can enable this by either specifying --wait-output=progress each time or setting the env vars SONOBUOY_PLUGIN_INSTALLATION=true or SONOBUOY_ALL_FEATURES=true.
```
