### PR TITLE
pkg/client/results: fix dropped test error

### DIFF
--- a/pkg/client/results/junit_test.go
+++ b/pkg/client/results/junit_test.go
@@ -26,6 +26,9 @@ func (e *errReader) Read(p []byte) (n int, err error) {
 func TestJUnitProcessReader(t *testing.T) {
 	xmlFromFile := func(path string) io.Reader {
 		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("Failed to open test file %v:%v", path, err)
+		}
 		defer f.Close()
 		var bb bytes.Buffer
 		_, err = io.Copy(&bb, f)


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>


**What this PR does / why we need it**:

This fixes a dropped test error in `pkg/client/results`.

**Release note**:
```
release-note NONE
```
