### PR TITLE
Add filename flag for retrieve

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -48,6 +48,7 @@ const (
 	e2eParallelFlag       = "e2e-parallel"
 	e2eRegistryConfigFlag = "e2e-repo-config"
 	pluginImageFlag       = "plugin-image"
+	filenameFlag          = "filename"
 
 	// Quick runs a single E2E test and the systemd log tests.
 	Quick string = "quick"
@@ -401,6 +402,14 @@ func AddExtractFlag(flag *bool, flags *pflag.FlagSet) {
 	flags.BoolVarP(
 		flag, "extract", "x", false,
 		"If true, extracts the results instead of just downloading the results tarball.",
+	)
+}
+
+// AddFilename initialises a namespace flag.
+func AddFilenameFlag(str *string, flags *pflag.FlagSet) {
+	flags.StringVarP(
+		str, filenameFlag, "f", "",
+		"Specify the name of the downloaded file. If empty, defaults to the name of the tarball in the pod.",
 	)
 }
 

--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -38,6 +38,7 @@ type retrieveFlags struct {
 	kubecfg        Kubeconfig
 	extract        bool
 	outputLocation string
+	filename       string
 }
 
 func NewCmdRetrieve() *cobra.Command {
@@ -52,6 +53,8 @@ func NewCmdRetrieve() *cobra.Command {
 	AddKubeconfigFlag(&rcvFlags.kubecfg, cmd.Flags())
 	AddNamespaceFlag(&rcvFlags.namespace, cmd.Flags())
 	AddExtractFlag(&rcvFlags.extract, cmd.Flags())
+	AddFilenameFlag(&rcvFlags.filename, cmd.Flags())
+
 	return cmd
 }
 
@@ -91,7 +94,7 @@ func retrieveResults(opts retrieveFlags, r io.Reader, ec <-chan error) error {
 	eg.Go(func() error { return <-ec })
 	eg.Go(func() error {
 		// This untars the request itself, which is tar'd as just part of the API request, not the sonobuoy logic.
-		filesCreated, err := client.UntarAll(r, opts.outputLocation, "")
+		filesCreated, err := client.UntarAll(r, opts.outputLocation, opts.filename)
 		if err != nil {
 			return err
 		}
@@ -100,6 +103,7 @@ func retrieveResults(opts retrieveFlags, r io.Reader, ec <-chan error) error {
 			for _, name := range filesCreated {
 				fmt.Println(name)
 			}
+
 			return nil
 		} else {
 			for _, filename := range filesCreated {

--- a/pkg/client/retrieve_test.go
+++ b/pkg/client/retrieve_test.go
@@ -59,3 +59,41 @@ func TestRetrieveInvalidConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestGetFilename(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		input  string
+		count  int
+		expect string
+	}{
+		{
+			desc:   "0 leads to no suffix",
+			input:  "foo",
+			expect: "foo",
+		}, {
+			desc:   "<0 leads to no suffix",
+			input:  "foo",
+			expect: "foo",
+			count:  -1,
+		}, {
+			desc:   ">0 leads to suffix",
+			input:  "foo",
+			expect: "foo-01",
+			count:  1,
+		}, {
+			desc:   "Suffix is before ext",
+			input:  "foo.ext",
+			expect: "foo-01.ext",
+			count:  1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			o := getFilename(tc.input, tc.count)
+			if o != tc.expect {
+				t.Errorf("Expected %v but got %v", tc.expect, o)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows the ability to specify the exact name of the file downloaded.

This helps script around this command in situations where you don't have
a shell to capture/manipulate it easily.

Fixes: #1361

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
You can now specify the exact filename of the tarball downloaded via `sonobuoy retrieve -f out.tar.gz`
```
