### PR TITLE
Fix regression regarding certified-conformance mode

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -466,8 +466,14 @@ func (m *Mode) Set(str string) error {
 		if err := m.env.Set(fmt.Sprintf("e2e.E2E_FOCUS=%v", quickFocus)); err != nil {
 			return fmt.Errorf("failed to set flag with value %v", str)
 		}
+		if err := m.env.Set("e2e.E2E_SKIP"); err != nil {
+			return fmt.Errorf("failed to set flag with value %v", str)
+		}
 	case CertifiedConformance:
 		if err := m.env.Set(fmt.Sprintf("e2e.E2E_FOCUS=%v", conformanceFocus)); err != nil {
+			return fmt.Errorf("failed to set flag with value %v", str)
+		}
+		if err := m.env.Set("e2e.E2E_SKIP"); err != nil {
 			return fmt.Errorf("failed to set flag with value %v", str)
 		}
 	default:

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -495,7 +495,7 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			expectFile: "testdata/gen-variable-image.golden",
 		}, {
 			desc:       "gen doesnt provide UUID",
-			cmdLine:    "gen",
+			cmdLine:    "gen --kubernetes-version=ignore",
 			expectFile: "testdata/gen-no-uuid.golden",
 		}, {
 			desc:       "gen config doesnt provide UUID",
@@ -503,15 +503,15 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			expectFile: "testdata/gen-config-no-uuid.golden",
 		}, {
 			desc:       "gen with config testing fields that also have flags",
-			cmdLine:    "gen --config=testdata/subfieldTest.json",
+			cmdLine:    "gen --config=testdata/subfieldTest.json --kubernetes-version=ignore",
 			expectFile: "testdata/gen-config-no-flags.golden",
 		}, {
 			desc:       "gen with flags targeting nested config fields",
-			cmdLine:    "gen -n=cmdlineNS --image-pull-policy=Always --sonobuoy-image=cmdlineimg --timeout=99",
+			cmdLine:    "gen -n=cmdlineNS --image-pull-policy=Always --sonobuoy-image=cmdlineimg --timeout=99 --kubernetes-version=ignore",
 			expectFile: "testdata/gen-subfield-flags.golden",
 		}, {
 			desc:       "gen with config then flags targeting subfields",
-			cmdLine:    "gen --config=testdata/subfieldTest.json -n cmdlineNS --image-pull-policy=Always --sonobuoy-image=cmdlineimg --timeout=99",
+			cmdLine:    "gen --config=testdata/subfieldTest.json -n cmdlineNS --image-pull-policy=Always --sonobuoy-image=cmdlineimg --timeout=99 --kubernetes-version=ignore",
 			expectFile: "testdata/gen-config-then-flags.golden",
 		}, {
 			desc:       "gen respects kube-conformance-image for both plugin and config issue 1376",
@@ -519,8 +519,12 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			expectFile: "testdata/gen-issue-1376.golden",
 		}, {
 			desc:       "e2e-repo-config should cause KUBE_TEST_REPO_LIST env var to match location used for mount",
-			cmdLine:    "gen --e2e-repo-config=./testdata/tiny-configmap.yaml",
+			cmdLine:    "gen --e2e-repo-config=./testdata/tiny-configmap.yaml --kubernetes-version=ignore",
 			expectFile: "testdata/gen-issue-1375.golden",
+		}, {
+			desc:       "certified conformance should have no skip value",
+			cmdLine:    "gen --mode=certified-conformance --kubernetes-version=ignore",
+			expectFile: "testdata/gen-issue-1388.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -96,8 +96,8 @@ data:
       - name: E2E_USE_GO_RUNNER
         value: "true"
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
-      image: k8s.gcr.io/conformance:v1.20.0
+        value: ignore
+      image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
       resources: {}
@@ -125,7 +125,7 @@ data:
       - name: RESULTS_DIR
         value: /tmp/results
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
+        value: ignore
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: Always
       name: systemd-logs

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -106,8 +106,8 @@ data:
       - name: KUBE_TEST_REPO_LIST
         value: /tmp/sonobuoy/config/tiny-configmap.yaml
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
-      image: k8s.gcr.io/conformance:v1.20.0
+        value: ignore
+      image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
@@ -137,7 +137,7 @@ data:
       - name: RESULTS_DIR
         value: /tmp/results
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
+        value: ignore
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: configfileNS
+  name: sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10,31 +10,31 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: configfileNS
+  namespace: sonobuoy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: configfileNS
-  name: sonobuoy-serviceaccount-configfileNS
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sonobuoy-serviceaccount-configfileNS
+  name: sonobuoy-serviceaccount-sonobuoy
 subjects:
 - kind: ServiceAccount
   name: sonobuoy-serviceaccount
-  namespace: configfileNS
+  namespace: sonobuoy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: configfileNS
-  name: sonobuoy-serviceaccount-configfileNS
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:
   - '*'
@@ -52,13 +52,13 @@ rules:
 apiVersion: v1
 data:
   config.json: |
-    {"Description":"DEFAULT","UUID":"","Version":"vSubfieldTestVersion","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":12345},"Plugins":[{"name":"configpluginval"}],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"configfileNS","WorkerImage":"configImg","ImagePullPolicy":"Never","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
+    {"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy","Resources":["apiservices","certificatesigningrequests","clusterrolebindings","clusterroles","componentstatuses","configmaps","controllerrevisions","cronjobs","customresourcedefinitions","daemonsets","deployments","endpoints","ingresses","jobs","leases","limitranges","mutatingwebhookconfigurations","namespaces","networkpolicies","nodes","persistentvolumeclaims","persistentvolumes","poddisruptionbudgets","pods","podlogs","podsecuritypolicies","podtemplates","priorityclasses","replicasets","replicationcontrollers","resourcequotas","rolebindings","roles","servergroups","serverversion","serviceaccounts","services","statefulsets","storageclasses","validatingwebhookconfigurations","volumeattachments"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099"}
 kind: ConfigMap
 metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: configfileNS
+  namespace: sonobuoy
 ---
 apiVersion: v1
 data:
@@ -91,14 +91,12 @@ data:
         value: \[Conformance\]
       - name: E2E_PARALLEL
         value: "false"
-      - name: E2E_SKIP
-        value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
       - name: SONOBUOY_K8S_VERSION
         value: ignore
       image: k8s.gcr.io/conformance:ignore
-      imagePullPolicy: Never
+      imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
       volumeMounts:
@@ -127,7 +125,7 @@ data:
       - name: SONOBUOY_K8S_VERSION
         value: ignore
       image: sonobuoy/systemd-logs:v0.3
-      imagePullPolicy: Never
+      imagePullPolicy: IfNotPresent
       name: systemd-logs
       resources: {}
       securityContext:
@@ -142,7 +140,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: configfileNS
+  namespace: sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -153,7 +151,7 @@ metadata:
     sonobuoy-component: aggregator
     tier: analysis
   name: sonobuoy
-  namespace: configfileNS
+  namespace: sonobuoy
 spec:
   containers:
   - env:
@@ -161,8 +159,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: configImg
-    imagePullPolicy: Never
+    image: sonobuoy/sonobuoy:*STATIC_FOR_TESTING*
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -193,7 +191,7 @@ metadata:
     component: sonobuoy
     sonobuoy-component: aggregator
   name: sonobuoy-aggregator
-  namespace: configfileNS
+  namespace: sonobuoy
 spec:
   ports:
   - port: 8080

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -96,8 +96,8 @@ data:
       - name: E2E_USE_GO_RUNNER
         value: "true"
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
-      image: k8s.gcr.io/conformance:v1.20.0
+        value: ignore
+      image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       resources: {}
@@ -125,7 +125,7 @@ data:
       - name: RESULTS_DIR
         value: /tmp/results
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
+        value: ignore
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -96,8 +96,8 @@ data:
       - name: E2E_USE_GO_RUNNER
         value: "true"
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
-      image: k8s.gcr.io/conformance:v1.20.0
+        value: ignore
+      image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
       resources: {}
@@ -125,7 +125,7 @@ data:
       - name: RESULTS_DIR
         value: /tmp/results
       - name: SONOBUOY_K8S_VERSION
-        value: v1.20.0
+        value: ignore
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: Always
       name: systemd-logs


### PR DESCRIPTION
When the mode is set as certified conformance mode, the skip value
does not get properly reset and as a result skips the disruptive
tests.

Fixes: #1388

Signed-off-by: John Schnake <jschnake@vmware.com>