### PR TITLE
Fix docs links for 1388 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](https://sonobuoy.io/docs/v0.53.1/issue1388.md). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 

--- a/site/content/docs/master/_index.md
+++ b/site/content/docs/master/_index.md
@@ -173,7 +173,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](https://sonobuoy.io/docs/v0.53.1/issue1388.md). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 

--- a/site/content/docs/master/issue1388.md
+++ b/site/content/docs/master/issue1388.md
@@ -1,0 +1,25 @@
+# Issue Regarding Certified-Conformance Mode
+
+### Versions of Sonobuoy Impacted
+ - v0.53.0
+ - v0.53.1
+
+### Description
+
+When running `sonobuoy run --mode=certified-conformance` the `E2E_SKIP` value is not properly cleared, leading to `disruptive` tests being skipped. In certified-conformance mode, all tests must be run to be valid for submission to the CNCF so this bug would invalidate your results.
+
+### Work-around #1
+
+You can manually work-around this issue by adding an extra flag at the end of your command:
+```
+sonobuoy run --mode=certified-conformance --plugin-env e2e.E2E_SKIP
+```
+This will set the focus value to conformance as expected and then remove the E2E_SKIP value.
+
+### Work-around #2
+
+Use a patched version of Sonobuoy. After this bug was reported and patched, we released v0.53.2.
+
+### Original issue
+
+Thanks to [BobyMCbobs](https://github.com/BobyMCbobs) for reporting the original issue: https://github.com/vmware-tanzu/sonobuoy/issues/1388

--- a/site/content/docs/v0.53.1/_index.md
+++ b/site/content/docs/v0.53.1/_index.md
@@ -173,7 +173,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](https://sonobuoy.io/docs/v0.53.1/issue1388.md). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 

--- a/site/content/docs/v0.53.2/_index.md
+++ b/site/content/docs/v0.53.2/_index.md
@@ -173,7 +173,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](https://sonobuoy.io/docs/v0.53.1/issue1388.md). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 

--- a/site/content/docs/v0.53.2/issue1388.md
+++ b/site/content/docs/v0.53.2/issue1388.md
@@ -1,0 +1,25 @@
+# Issue Regarding Certified-Conformance Mode
+
+### Versions of Sonobuoy Impacted
+ - v0.53.0
+ - v0.53.1
+
+### Description
+
+When running `sonobuoy run --mode=certified-conformance` the `E2E_SKIP` value is not properly cleared, leading to `disruptive` tests being skipped. In certified-conformance mode, all tests must be run to be valid for submission to the CNCF so this bug would invalidate your results.
+
+### Work-around #1
+
+You can manually work-around this issue by adding an extra flag at the end of your command:
+```
+sonobuoy run --mode=certified-conformance --plugin-env e2e.E2E_SKIP
+```
+This will set the focus value to conformance as expected and then remove the E2E_SKIP value.
+
+### Work-around #2
+
+Use a patched version of Sonobuoy. After this bug was reported and patched, we released v0.53.2.
+
+### Original issue
+
+Thanks to [BobyMCbobs](https://github.com/BobyMCbobs) for reporting the original issue: https://github.com/vmware-tanzu/sonobuoy/issues/1388


### PR DESCRIPTION
The docs have some special logic to try and redirect to the right
version of any given link. I've tried hardcoding the values for the
full URL but it isnt working for some reason. By just copying the file
into a few more places the links becomes much more simple.

Signed-off-by: John Schnake <jschnake@vmware.com>