### PR TITLE
Fix docs links for 1388 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 
@@ -199,6 +199,7 @@ See [the list of releases][releases] to find out about feature changes.
 [customPlugins]: https://sonobuoy.io/docs/plugins
 [gen]: https://sonobuoy.io/docs/gen
 [issue]: https://github.com/vmware-tanzu/sonobuoy/issues
+[issue1388]: https://sonobuoy.io/docs/issue1388
 [k8s]: https://github.com/kubernetes/kubernetes
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
 [oview]: https://youtu.be/8QK-Hg2yUd4

--- a/site/content/docs/master/_index.md
+++ b/site/content/docs/master/_index.md
@@ -173,7 +173,7 @@ kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrol
 
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here](issue1388). The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 
@@ -205,6 +205,7 @@ See [the list of releases][releases] to find out about feature changes.
 [customPlugins]: plugins
 [gen]: gen
 [issue]: https://github.com/vmware-tanzu/sonobuoy/issues
+[issue1388]: issue1388
 [k8s]: https://github.com/kubernetes/kubernetes
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
 [oview]: https://youtu.be/8QK-Hg2yUd4


### PR DESCRIPTION
As usual, the markdown for the github readme and the markdown for the
main docs site are the same but handle links different. So now the site worked
right but not the github repo readme for this link.

Signed-off-by: John Schnake <jschnake@vmware.com>