### PR TITLE
Fix feature gate name

### DIFF
--- a/cmd/sonobuoy/app/featureGates.go
+++ b/cmd/sonobuoy/app/featureGates.go
@@ -7,7 +7,7 @@ const (
 
 	FeaturePluginInstallation = "SONOBUOY_PLUGIN_INSTALLATION"
 
-	FeatureWaitOutputProgressByDefault = "SONOBUOY_PLUGIN_INSTALLATION"
+	FeatureWaitOutputProgressByDefault = "SONOBUOY_WAIT_PROGRESS"
 )
 
 func featureEnabled(feature string) bool {


### PR DESCRIPTION
Just a copy/paste bug. Typically I use SONOBUOY_ALL_FEATURES so I
hadn't seen this until now.

Signed-off-by: John Schnake <jschnake@vmware.com>

