### PR TITLE
Adjust the logic for processing plugin results for aggregator status

### DIFF
--- a/pkg/plugin/aggregation/aggregator.go
+++ b/pkg/plugin/aggregation/aggregator.go
@@ -232,7 +232,6 @@ func (a *Aggregator) processResult(result *plugin.Result) error {
 }
 
 // processProgressUpdate is the main aggregator logic for handling the progress updates from plugins.
-// We first
 func (a *Aggregator) processProgressUpdate(progress plugin.ProgressUpdate) error {
 	a.resultsMutex.Lock()
 	expected := a.isExpected(progress)

--- a/pkg/plugin/aggregation/status_test.go
+++ b/pkg/plugin/aggregation/status_test.go
@@ -40,9 +40,9 @@ func TestUpdateStatus(t *testing.T) {
 			expectedStatus: "running",
 		},
 		{
-			name:           "one failed is failed",
+			name:           "one running is running even if others failed",
 			pluginStatuses: []string{"running", "failed", "complete"},
-			expectedStatus: "failed",
+			expectedStatus: "running",
 		},
 	}
 

--- a/pkg/plugin/aggregation/update_test.go
+++ b/pkg/plugin/aggregation/update_test.go
@@ -51,7 +51,7 @@ func TestCreateUpdater(t *testing.T) {
 		t.Errorf("unexpected error receiving update %v", err)
 	}
 
-	if updater.status.Status != FailedStatus {
+	if updater.status.Status != RunningStatus {
 		t.Errorf("expected status to be failed, got %v", updater.status.Status)
 	}
 }
@@ -282,7 +282,7 @@ func TestReceive(t *testing.T) {
 					{Node: "node2", Plugin: "type1", Status: "failed"},
 					{Node: "global", Plugin: "type2", Status: "running"},
 				},
-				Status: "failed",
+				Status: "running",
 			},
 			results: map[string]*plugin.Result{
 				"type1/node1": {NodeName: "node1", ResultType: "type1"},


### PR DESCRIPTION
IF a test fails that indicates it fails, not Sonobuoy. I think the current
logic which labels the whole run as "failed" is incorrect now that the tool
has evolved to run more plugins.

Instead, the aggregator should only be marked failed if the aggregator itself
fails to get results and get them to the user.

Fixes #1414

Signed-off-by: John Schnake <jschnake@vmware.com>

### Release Note
```
A slight change to the meaning of the aggregators status values. It is now the case that even if a single (or all) the plugins fail, the aggregator itself is marked as `complete` since the aggregator status is seperate from the plugin results. The aggregator status continues to hold all the plugin status values which can be inspected if that is your goal. Typically, the aggregator status is simply used to determine if the run has started, is running, or is complete so that other actions like downloading the results can be taken.
```