### PR TITLE
Added validation to gen [plugin] for plugin name

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -208,6 +208,12 @@ func genPluginDef(cfg *GenPluginDefConfig) ([]byte, error) {
 		cfg.def.ConfigMap[base] = string(fData)
 	}
 
+	// Ensure a config with this plugin would validate
+	gc := client.GenConfig{StaticPlugins: []*manifest.Manifest{&cfg.def}}
+	if err := gc.Validate(); err != nil {
+		return nil, errors.Wrap(err, "plugin failed validation")
+	}
+
 	yaml, err := kuberuntime.Encode(manifest.Encoder, &cfg.def)
 	return yaml, errors.Wrap(err, "serializing as YAML")
 }

--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -38,6 +38,7 @@ func TestPluginGenDef(t *testing.T) {
 			desc: "Container fields",
 			cfg: GenPluginDefConfig{
 				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "emptynotallowed"},
 					Spec: manifest.Container{
 						Container: v1.Container{
 							Name:    "n",
@@ -51,7 +52,7 @@ func TestPluginGenDef(t *testing.T) {
 		}, {
 			desc: "Env vars",
 			cfg: GenPluginDefConfig{
-				def: manifest.Manifest{},
+				def: manifest.Manifest{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "emptynotallowed"}},
 				env: map[string]string{"FOO": "bar"},
 			},
 			expectFile: "testdata/pluginDef-env.golden",

--- a/cmd/sonobuoy/app/testdata/pluginDef-container.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-container.golden
@@ -1,6 +1,6 @@
 sonobuoy-config:
   driver: ""
-  plugin-name: ""
+  plugin-name: emptynotallowed
 spec:
   command:
   - /bin/sh

--- a/cmd/sonobuoy/app/testdata/pluginDef-env.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-env.golden
@@ -1,6 +1,6 @@
 sonobuoy-config:
   driver: ""
-  plugin-name: ""
+  plugin-name: emptynotallowed
 spec:
   env:
   - name: FOO

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -17,7 +17,9 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,6 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+)
+
+const (
+	nameRegexpString = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 )
 
 // LogConfig are the input options for viewing a Sonobuoy run's logs.
@@ -92,6 +98,12 @@ type GenConfig struct {
 
 // Validate checks the config to determine if it is valid.
 func (gc *GenConfig) Validate() error {
+	nameRegexp := regexp.MustCompile(nameRegexpString)
+	for _, m := range gc.StaticPlugins {
+		if !nameRegexp.MatchString(m.SonobuoyConfig.PluginName) {
+			return fmt.Errorf("invalid plugin name %q; name must only include lowercase alphanumeric values '.' or '-'. This is due to Kubernetes requiring various values to follow RFC 1123 for valid subdomain names", m.SonobuoyConfig.PluginName)
+		}
+	}
 	return nil
 }
 

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -559,6 +560,14 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			desc:       "gen rerun-failed should err if no failures",
 			cmdLine:    "gen --rerun-failed testdata/results-quick-no-failures.tar.gz --kubernetes-version=ignore",
 			expectFile: "testdata/gen-rerunfailed-no-failures.golden",
+		}, {
+			desc:       "gen plugin should should run plugin name validation",
+			cmdLine:    "gen plugin -n badcharS -i foo",
+			expectFile: "testdata/gen-plugin-nobadchars.golden",
+		}, {
+			desc:       "gen should run plugin name validation",
+			cmdLine:    "gen -p testdata/plugins/badpluginname.yaml --kubernetes-version=ignore",
+			expectFile: "testdata/gen-nobadchars.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-nobadchars.golden
+++ b/test/integration/testdata/gen-nobadchars.golden
@@ -1,0 +1,1 @@
+time="STATIC_TIME_FOR_TESTING" level=error msg="error attempting to generate sonobuoy manifest: config validation failed: invalid plugin name \"badName\"; name must only include lowercase alphanumeric values '.' or '-'. This is due to Kubernetes requiring various values to follow RFC 1123 for valid subdomain names"

--- a/test/integration/testdata/gen-plugin-nobadchars.golden
+++ b/test/integration/testdata/gen-plugin-nobadchars.golden
@@ -1,0 +1,1 @@
+time="STATIC_TIME_FOR_TESTING" level=error msg="plugin failed validation: invalid plugin name \"badcharS\"; name must only include lowercase alphanumeric values '.' or '-'. This is due to Kubernetes requiring various values to follow RFC 1123 for valid subdomain names"

--- a/test/integration/testdata/plugins/badpluginname.yaml
+++ b/test/integration/testdata/plugins/badpluginname.yaml
@@ -1,0 +1,14 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: badName
+  result-format: raw
+spec:
+  command:
+  - ./run.sh
+  image: foo
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+


### PR DESCRIPTION
To avoid errors where/if users use capital letters or
special characters, I've added basic validation to the
logic and new tests. The regexp comes from k8s throwing
the error and has the RFC reference for clarity.

Fixes #1413

Signed-off-by: John Schnake <jschnake@vmware.com>

### Release Note
```
Plugin names must include only alphanumeric values and '.' or '-'. This is is in line with numerous objects requiring this naming scheme in Kubernetes and avoiding conflicts as we name objects related to those plugins.
```