### PR TITLE
 Add sleep parameter to job plugins worker container

### DIFF
--- a/pkg/discovery/pods.go
+++ b/pkg/discovery/pods.go
@@ -84,10 +84,10 @@ func gatherPodLogs(kubeClient kubernetes.Interface, ns string, opts metav1.ListO
 	// 2 - Foreach pod, dump each of its containers' logs in a tree in the following location:
 	//   pods/:podname/logs/:containername.txt
 	for _, pod := range podlist.Items {
-		if _, ok := visitedPods[pod.SelfLink]; ok {
+		if _, ok := visitedPods[string(pod.UID)]; ok {
 			continue // skip visited pods
 		}
-		visitedPods[pod.SelfLink] = struct{}{}
+		visitedPods[string(pod.UID)] = struct{}{}
 
 		if pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted" {
 			logrus.WithField("podName", pod.Name).Info("Skipping evicted pod.")

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -39,6 +39,11 @@ import (
 const (
 	// pollingInterval is the time between polls when monitoring the job status.
 	pollingInterval = 10 * time.Second
+
+	// defaultSleepSeconds is the time after the plugin finishes for which Sonobuoy will sleep.
+	// The sleep functions as a way to prevent the job from being terminated before we get podlogs
+	// during the query phase of the run.
+	defaultSleepSeconds = "-1"
 )
 
 // Plugin is a plugin driver that dispatches a single pod to the given
@@ -116,7 +121,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "-v", "5", "--logtostderr"}, progressPort),
+		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "-v=5", "--sleep=" + defaultSleepSeconds, "--logtostderr"}, progressPort),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -174,7 +174,10 @@ func TestSimpleRun(t *testing.T) {
 	mustRunSonobuoyCommandWithContext(ctx, t, args)
 }
 
-func TestRetrieveAndExtract(t *testing.T) {
+// TestRetrieveAndExtractWithPodLogs tests that we are able to extract the files
+// from the tarball via the retrieve command. It also ensures that we dont
+// regress on #1415, that plugin pod logs should be gathered.
+func TestRetrieveAndExtractWithPodLogs(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -182,7 +185,7 @@ func TestRetrieveAndExtract(t *testing.T) {
 	ns, cleanup := getNamespace(t)
 	defer cleanup()
 
-	args := fmt.Sprintf("run --image-pull-policy IfNotPresent --wait -p testImage/yaml/job-junit-passing-singlefile.yaml -n %v", ns)
+	args := fmt.Sprintf("run --image-pull-policy IfNotPresent --wait -p testImage/yaml/job-junit-passing-singlefile.yaml -p testImage/yaml/ds-junit-passing-tar.yaml -n %v", ns)
 	mustRunSonobuoyCommandWithContext(ctx, t, args)
 
 	// Create tmpdir and extract contents into it
@@ -214,6 +217,20 @@ func TestRetrieveAndExtract(t *testing.T) {
 	t.Logf("Extracted files:\n%v", strings.Join(files, "\n\t-"))
 	if len(files) < 20 {
 		t.Errorf("Expected many files to be extracted into %v, but only got %v", tmpdir, len(files))
+	}
+
+	// This is the logic that ensures that multiple pod logs were gathered.
+	podLogCount := 0
+	for _, f := range files {
+		if strings.HasPrefix(f, filepath.Join(tmpdir, "podlogs", ns)) &&
+			strings.HasSuffix(f, "/logs") {
+			podLogCount++
+		}
+	}
+	// Should have one for each node/plugin combo expected. Here 2 for the daemonset, the aggregator,
+	// and the job.
+	if podLogCount < 4 {
+		t.Errorf("Expected 4 pod logs to be gathered (2 for the daemonset, aggregator, and job) but only got %v", podLogCount)
 	}
 }
 
@@ -303,6 +320,12 @@ func checkTarballPluginForErrors(t *testing.T, tarball, plugin string, failCount
 	if !strings.Contains(out.String(), expectOut) {
 		t.Errorf("Expected output of %q to contain %q but output was %v", args, expectOut, out.String())
 	}
+}
+
+func mustDownloadTarballExtract(ctx context.Context, t *testing.T, ns, extractTo string) {
+	args := fmt.Sprintf("retrieve -n %v -x %v", ns, extractTo)
+	mustRunSonobuoyCommandWithContext(ctx, t, args)
+	t.Logf("Tarball downloaded and extracted to: %v", extractTo)
 }
 
 func saveToArtifacts(t *testing.T, p string) (newPath string) {


### PR DESCRIPTION
Without this, the container exits after submitting results
and leads to the pod being shut down before we can query
the logs. In some plugins (like e2e) it isn't that big of
an issue, but for plugins that don't separately save their
logs or if we want to debug the worker container, it is
vital.

Fixes #1415 

Signed-off-by: John Schnake <jschnake@vmware.com>