### PR TITLE
Add default security context to aggregator

### DIFF
--- a/pkg/client/gen.tmpl.yaml
+++ b/pkg/client/gen.tmpl.yaml
@@ -102,6 +102,10 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
 {{- if .NodeSelectors }}
   nodeSelector:{{- range $k, $v := .NodeSelectors }}
     {{ indent 4 $k}}: {{$v}}

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -125,6 +125,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -80,6 +80,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -80,6 +80,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -80,6 +80,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -83,6 +83,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -78,6 +78,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/imagePullPolicy-all-plugins.golden
+++ b/pkg/client/testdata/imagePullPolicy-all-plugins.golden
@@ -64,6 +64,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -80,6 +80,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -90,6 +90,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -84,6 +84,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -52,6 +52,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -80,6 +80,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   nodeSelector:
     fizz: buzz
     foo: bar

--- a/pkg/client/testdata/plugin-configmaps.golden
+++ b/pkg/client/testdata/plugin-configmaps.golden
@@ -84,6 +84,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -64,6 +64,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   nodeSelector:
     foo: bar
   containers:

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -114,6 +114,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -54,6 +54,10 @@ metadata:
   name: sonobuoy
   namespace: 
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -154,6 +154,10 @@ metadata:
   name: sonobuoy
   namespace: configfileNS
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -154,6 +154,10 @@ metadata:
   name: sonobuoy
   namespace: cmdlineNS
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -166,6 +166,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -155,6 +155,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -152,6 +152,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -154,6 +154,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -157,6 +157,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -121,6 +121,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -154,6 +154,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -154,6 +154,10 @@ metadata:
   name: sonobuoy
   namespace: cmdlineNS
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -115,6 +115,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/plugin-loading-installed.golden
+++ b/test/integration/testdata/plugin-loading-installed.golden
@@ -99,6 +99,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP

--- a/test/integration/testdata/plugin-loading-local.golden
+++ b/test/integration/testdata/plugin-loading-local.golden
@@ -99,6 +99,10 @@ metadata:
   name: sonobuoy
   namespace: sonobuoy
 spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
   containers:
   - env:
     - name: SONOBUOY_ADVERTISE_IP


### PR DESCRIPTION
There is no elevetated priviledge that the aggregator needs on the node
so we should be fine to add this security context which makes it
clear that we are not operating as root in any sense.

Fixes #1410

Signed-off-by: John Schnake <jschnake@vmware.com>

** Notes **
In addition to CI, I ran this locally against kind and it worked fine on quick mode. I was able to get/download/inspect results without issue.

**Release note**:
```
The aggregator pod is now run with a security context specified which explicitly makes it run as non-root user/group/fsgroup. This should avoid sonobuoy being blocked by certain security sweeps.
```
