### PR TITLE
Adds easy way for devs to swap their own registry

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -100,7 +100,7 @@ func AddDNSPodLabelsFlag(str *[]string, flags *pflag.FlagSet) {
 // AddSonobuoyImage initialises an image url flag.
 func AddSonobuoyImage(image *string, flags *pflag.FlagSet) {
 	flags.StringVar(
-		image, sonobuoyImageFlag, config.DefaultImage,
+		image, sonobuoyImageFlag, *image,
 		"Container image override for the sonobuoy worker and aggregator.",
 	)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -365,6 +367,10 @@ func New() *Config {
 	}
 
 	cfg.WorkerImage = DefaultImage
+	devRepo := os.Getenv("SONOBUOY_DEV_REPO")
+	if len(devRepo) > 0 {
+		cfg.WorkerImage = fmt.Sprintf("%v/sonobuoy:%v", devRepo, buildinfo.Version)
+	}
 	cfg.ImagePullPolicy = DefaultSonobuoyPullPolicy
 
 	cfg.ProgressUpdatesPort = DefaultProgressUpdatesPort


### PR DESCRIPTION
Without this you have to constantly change the flags depending
on the command and its verbose/painful. This will just be
a hidden little developer helper.

Signed-off-by: John Schnake <jschnake@vmware.com>