### PR TITLE
Do not use deprecated SelfLink

### DIFF
--- a/pkg/discovery/pods.go
+++ b/pkg/discovery/pods.go
@@ -84,10 +84,10 @@ func gatherPodLogs(kubeClient kubernetes.Interface, ns string, opts metav1.ListO
 	// 2 - Foreach pod, dump each of its containers' logs in a tree in the following location:
 	//   pods/:podname/logs/:containername.txt
 	for _, pod := range podlist.Items {
-		if _, ok := visitedPods[pod.SelfLink]; ok {
+		if _, ok := visitedPods[string(pod.UID)]; ok {
 			continue // skip visited pods
 		}
-		visitedPods[pod.SelfLink] = struct{}{}
+		visitedPods[string(pod.UID)] = struct{}{}
 
 		if pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted" {
 			logrus.WithField("podName", pod.Name).Info("Skipping evicted pod.")


### PR DESCRIPTION
The SelfLink value was being used as a UUID (I guess so it was
readable?) but has been deprecated and now always reads as empty.

This caused pod logs to not be gathered as expected.

Fixes #1415

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Fixes a bug causing most pod logs (even in the sonobuoy namespace) to be queried at the end of the run despite logs indicating that they were.
```
