### PR TITLE
Removed managed fields from query output

### DIFF
--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -63,7 +63,7 @@ func timedListQuery(outpath string, file string, f listQuery) (time.Duration, er
 	}
 
 	if len(list.Items) > 0 {
-		err = errors.WithStack(SerializeObj(list.Items, outpath, file))
+		err = errors.WithStack(SerializeObj(list, outpath, file))
 	}
 	return duration, err
 }


### PR DESCRIPTION
It is a confusing waste of info and makes it much harder to look
at the output. In addition, it is not normally provided by kubectl
so users aren't even aware that it exists (I wasn't) and so it
makes the rest of the data seem more confusing than it needs to be.

Fixes #1428

Signed-off-by: John Schnake <jschnake@vmware.com>

**Special notes for your reviewer**:
You can use this command to test locally if you want:

```
sonobuoy run --mode=quick --sonobuoy-image=schnake/sonobuoy:devonly1632013611 --wait && sonobuoy retrieve -x nomanagedoutput
```

**Release note**:
```
Removes managedfields from the query data since this is generally meaningless to any user, and very often mostly empty, nested fields that clog up the meaningful data.
```
