### PR TITLE
Add more auto env vars to plugins

### DIFF
--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}
@@ -96,8 +102,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       name: systemd-logs
       resources: {}

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -58,8 +58,14 @@ data:
         value: override
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -53,8 +53,14 @@ data:
       - name: E2E_FOCUS
       - name: E2E_PARALLEL
       - name: E2E_SKIP
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/imagePullPolicy-all-plugins.golden
+++ b/pkg/client/testdata/imagePullPolicy-all-plugins.golden
@@ -31,8 +31,14 @@ data:
       plugin-name: myplugin1
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}
@@ -42,8 +48,14 @@ data:
       plugin-name: myplugin2
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}
@@ -69,8 +75,14 @@ data:
       plugin-name: foo
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       name: ""
       resources: {}
 kind: ConfigMap

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -31,8 +31,14 @@ data:
       plugin-name: foo
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       name: ""
       resources: {}
   plugin-1.yaml: |
@@ -55,8 +61,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       name: systemd-logs
       resources: {}

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -31,8 +31,14 @@ data:
       plugin-name: foo
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       name: ""
       resources: {}
 kind: ConfigMap

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       name: e2e
       resources: {}

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/plugin-configmaps.golden
+++ b/pkg/client/testdata/plugin-configmaps.golden
@@ -38,8 +38,14 @@ data:
       plugin-name: myplugin1
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}
@@ -59,8 +65,14 @@ data:
       plugin-name: myplugin2
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -31,8 +31,14 @@ data:
       plugin-name: a
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}
@@ -42,8 +48,14 @@ data:
       plugin-name: b
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
       name: ""
       resources: {}

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -55,8 +55,14 @@ data:
       - name: E2E_SKIP
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -84,8 +90,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -33,8 +33,14 @@ data:
       plugin-name: a
     spec:
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       name: ""
       resources: {}
 kind: ConfigMap

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: Never
       name: e2e
@@ -124,8 +130,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: Never
       name: systemd-logs

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
@@ -124,8 +130,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: Always
       name: systemd-logs

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -105,8 +105,14 @@ data:
         value: "true"
       - name: KUBE_TEST_REPO_LIST
         value: /tmp/sonobuoy/config/tiny-configmap.yaml
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -136,8 +142,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -96,8 +96,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v9.8.7
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v9.8.7
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -125,8 +131,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v9.8.7
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -93,8 +93,14 @@ data:
         value: "false"
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -122,8 +128,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -124,8 +130,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-plugin-e2e-configmap.golden
+++ b/test/integration/testdata/gen-plugin-e2e-configmap.golden
@@ -30,8 +30,14 @@ spec:
     value: \[Disruptive\]|NoExecuteTaintManager
   - name: E2E_USE_GO_RUNNER
     value: "true"
+  - name: SONOBUOY
+    value: "true"
+  - name: SONOBUOY_CONFIG_DIR
+    value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_RESULTS_DIR
+    value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e

--- a/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
+++ b/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
@@ -31,8 +31,14 @@ spec:
     value: \[Disruptive\]|NoExecuteTaintManager
   - name: E2E_USE_GO_RUNNER
     value: "true"
+  - name: SONOBUOY
+    value: "true"
+  - name: SONOBUOY_CONFIG_DIR
+    value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_RESULTS_DIR
+    value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e

--- a/test/integration/testdata/gen-plugin-e2e.golden
+++ b/test/integration/testdata/gen-plugin-e2e.golden
@@ -30,8 +30,14 @@ spec:
     value: \[Disruptive\]|NoExecuteTaintManager
   - name: E2E_USE_GO_RUNNER
     value: "true"
+  - name: SONOBUOY
+    value: "true"
+  - name: SONOBUOY_CONFIG_DIR
+    value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_RESULTS_DIR
+    value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -98,8 +98,14 @@ data:
         value: "false"
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -127,8 +133,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v123.456.789
       imagePullPolicy: IfNotPresent
       name: e2e

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v123.456.789
       imagePullPolicy: IfNotPresent
       name: e2e
@@ -124,8 +130,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: IfNotPresent
       name: systemd-logs

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -95,8 +95,14 @@ data:
         value: \[Disruptive\]|NoExecuteTaintManager
       - name: E2E_USE_GO_RUNNER
         value: "true"
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
@@ -124,8 +130,14 @@ data:
             fieldPath: spec.nodeName
       - name: RESULTS_DIR
         value: /tmp/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.3
       imagePullPolicy: Always
       name: systemd-logs

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -71,8 +71,14 @@ data:
       command:
       - ./run.sh
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: hello:v9
       imagePullPolicy: IfNotPresent
       name: plugin
@@ -89,8 +95,14 @@ data:
       command:
       - ./run.sh
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: hello:v123.456.789
       imagePullPolicy: IfNotPresent
       name: plugin

--- a/test/integration/testdata/plugin-loading-installed.golden
+++ b/test/integration/testdata/plugin-loading-installed.golden
@@ -73,8 +73,14 @@ data:
       command:
       - ./run.sh
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: hello:v9
       imagePullPolicy: IfNotPresent
       name: plugin

--- a/test/integration/testdata/plugin-loading-local.golden
+++ b/test/integration/testdata/plugin-loading-local.golden
@@ -73,8 +73,14 @@ data:
       command:
       - ./run.sh
       env:
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
       image: hello:v9
       imagePullPolicy: IfNotPresent
       name: plugin


### PR DESCRIPTION
For plugins to work well they need to know where to load
configs and where to save results. Rather than this being by
convention we should spell it out and provide the values in
an env var.

Fixes: #1427

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Adds SONOBUOY, SONOBUOY_RESULTS_DIR, and SONOBUOY_CONFIG_DIR env vars to all plugins dynamically so that plugins know that they were launched via Sonobuoy, where to load config maps from, and where to save results to.
```
