### PR TITLE
Improve various logging points on aggregator

### DIFF
--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/briandowns/spinner"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -109,7 +107,7 @@ func (c *SonobuoyClient) Delete(cfg *DeleteConfig) error {
 
 		switch cfg.WaitOutput {
 		case spinnerMode:
-			var s *spinner.Spinner = getSpinnerInstance()
+			var s = getSpinnerInstance()
 			s.Start()
 			defer s.Stop()
 		}
@@ -267,11 +265,11 @@ func cleanupE2E(client kubernetes.Interface) (ConditionFuncWithProgress, error) 
 func logDelete(log logrus.FieldLogger, err error) error {
 	switch {
 	case err == nil:
-		log.Info("deleted")
+		log.Info("delete request issued")
 	case kubeerror.IsNotFound(err):
 		log.Info("already deleted")
 	case kubeerror.IsConflict(err):
-		log.WithError(err).Info("delete in progress")
+		log.WithError(err).Info("delete already in progress")
 	case err != nil:
 		return err
 	}

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -41,11 +41,11 @@ import (
 )
 
 const (
-	bufferSize                    = 4096
-	pollInterval                  = 20 * time.Second
-	spinnerType     int           = 14
-	spinnerDuration time.Duration = 2000 * time.Millisecond
-	spinnerColor                  = "red"
+	bufferSize          = 4096
+	pollInterval        = 20 * time.Second
+	spinnerType     int = 14
+	spinnerDuration     = 2000 * time.Millisecond
+	spinnerColor        = "red"
 
 	// Special key for when to load manifest from stdin instead of a local file.
 	stdinFile = "-"
@@ -173,7 +173,7 @@ func (c *SonobuoyClient) RunManifest(cfg *RunConfig, manifest []byte) error {
 
 		switch cfg.WaitOutput {
 		case spinnerMode:
-			var s *spinner.Spinner = getSpinnerInstance()
+			var s = getSpinnerInstance()
 			s.Start()
 			defer s.Stop()
 		case progressMode:
@@ -238,7 +238,7 @@ func handleCreateError(name, namespace, resource string, err error) error {
 
 	switch {
 	case err == nil:
-		log.Info("created object")
+		log.Info("create request issued")
 	// Some resources (like ClusterRoleBinding and ClusterBinding) aren't
 	// namespaced and may overlap between runs. So don't abort on duplicate errors
 	// in this case.

--- a/pkg/plugin/aggregation/handler.go
+++ b/pkg/plugin/aggregation/handler.go
@@ -203,14 +203,18 @@ func GlobalResultURL(baseURL, pluginName string) (string, error) {
 
 func logRequest(req *http.Request) {
 	vars := mux.Vars(req)
-	log := logrus.WithField("plugin_name", vars["plugin"])
+	log := logrus.WithFields(map[string]interface{}{
+		"plugin_name": vars["plugin"],
+		"url":         req.URL,
+		"method":      req.Method,
+	})
 	if node := vars["node"]; node != "" {
 		log = log.WithField("node", node)
 	}
 	if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
-		log = log.WithField("client_cert", req.TLS.PeerCertificates[0].Subject.CommonName)
+		log = log.WithField("client_cert", req.TLS.PeerCertificates[0].DNSNames)
 	}
-	log.Info("received aggregator request")
+	log.Info("received request")
 }
 
 // filenameFromHeader gets the filename from a content-disposition of the form:


### PR DESCRIPTION
- tries to clarify that a creation/deletion refers to the API
request being issued, not completd
- disambiguate between progress requests and results requests
- add HTTP method when request is issued
- fix bug where subject.CommonName was used in logging when it
had been swapped for DNSNames in a previous PR

Fixes #1423
Fixes #1433
Fixes #1420

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Improved clarity of a number of logging points to provide more (and more accurate) data to avoid confusion.
```
