### PR TITLE
Add known issue related to docker desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,34 @@
 
 ## [Overview][oview]
 
-Sonobuoy is a diagnostic tool that makes it easier to understand the
-state of a Kubernetes cluster by running a set of plugins (including [Kubernetes][k8s] conformance
-tests) in an accessible and non-destructive manner. It is a customizable,
-extendable, and cluster-agnostic way to generate clear, informative reports
-about your cluster.
+Sonobuoy is a diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of
+plugins (including [Kubernetes][k8s] conformance tests) in an accessible and non-destructive manner. It is a
+customizable, extendable, and cluster-agnostic way to generate clear, informative reports about your cluster.
 
-Its selective data dumps of Kubernetes resource objects and cluster nodes allow
-for the following use cases:
+Its selective data dumps of Kubernetes resource objects and cluster nodes allow for the following use cases:
 
 * Integrated end-to-end (e2e) [conformance-testing][e2ePlugin]
 * Workload debugging
 * Custom data collection via extensible plugins
 
-Starting v0.20, Sonobuoy supports Kubernetes v1.17 or later.
-Sonobuoy releases will be independent of Kubernetes release, while ensuring that new releases continue to work functionally across different versions of Kubernetes.
-Read more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
+Starting v0.20, Sonobuoy supports Kubernetes v1.17 or later. Sonobuoy releases will be independent of Kubernetes
+release, while ensuring that new releases continue to work functionally across different versions of Kubernetes. Read
+more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
 
 > Note: You can skip this version enforcement by running Sonobuoy with the `--skip-preflight` flag.
 
 ## Prerequisites
 
-* Access to an up-and-running Kubernetes cluster. If you do not have a cluster,
-  we recommend following the [AWS Quickstart for Kubernetes][quickstart] instructions.
+* Access to an up-and-running Kubernetes cluster. If you do not have a cluster, we recommend following
+  the [AWS Quickstart for Kubernetes][quickstart] instructions.
 
 * An admin `kubeconfig` file, and the KUBECONFIG environment variable set.
 
-* For some advanced workflows it may be required to have `kubectl` installed. See [installing via Homebrew (MacOS)][brew] or [building
-  the binary (Linux)][linux].
+* For some advanced workflows it may be required to have `kubectl` installed.
+  See [installing via Homebrew (MacOS)][brew] or [building the binary (Linux)][linux].
 
-* The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed. See [installing Docker][docker].
+* The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed.
+  See [installing Docker][docker].
 
 ## Installation
 
@@ -63,7 +61,7 @@ Get the results from the plugins (e.g. e2e test results):
 results=$(sonobuoy retrieve)
 ```
 
-Inspect results for test failures.  This will list the number of tests failed and their names:
+Inspect results for test failures. This will list the number of tests failed and their names:
 
 ```bash
 sonobuoy results $results
@@ -73,11 +71,9 @@ sonobuoy results $results
 
 You can also extract the entire contents of the file to get much more [detailed data][snapshot] about your cluster.
 
-Sonobuoy creates a few resources in order to run and expects to run within its
-own namespace.
+Sonobuoy creates a few resources in order to run and expects to run within its own namespace.
 
-Deleting Sonobuoy entails removing its namespace as well as a few cluster
-scoped resources.
+Deleting Sonobuoy entails removing its namespace as well as a few cluster scoped resources.
 
 ```bash
 sonobuoy delete --wait
@@ -87,7 +83,8 @@ sonobuoy delete --wait
 
 ### Other Tests
 
-By default, `sonobuoy run` runs the Kubernetes conformance tests but this can easily be configured. The same plugin that has the conformance tests has all the Kubernetes end-to-end tests which include other tests such as:
+By default, `sonobuoy run` runs the Kubernetes conformance tests but this can easily be configured. The same plugin that
+has the conformance tests has all the Kubernetes end-to-end tests which include other tests such as:
 
 * tests for specific storage features
 * performance tests
@@ -97,7 +94,8 @@ By default, `sonobuoy run` runs the Kubernetes conformance tests but this can ea
 
 To modify which tests you want to run, checkout our page on the [e2e plugin][e2ePlugin].
 
-If you want to run other tests or tools which are not a part of the Kubernetes end-to-end suite, refer to our documentation on [custom plugins][customPlugins].
+If you want to run other tests or tools which are not a part of the Kubernetes end-to-end suite, refer to our
+documentation on [custom plugins][customPlugins].
 
 ### Monitoring Sonobuoy during a run
 
@@ -115,16 +113,17 @@ sonobuoy logs
 
 ## Troubleshooting
 
-If you encounter any problems that the documentation does not address, [file an
-issue][issue].
+If you encounter any problems that the documentation does not address, [file an issue][issue].
 
 ## Docker Hub rate limit
 
-This year, Docker has started rate limiting image pulls from Docker Hub. We're planning a future release with a better user interface to work around this. Until then, this is the recommended approach.
+This year, Docker has started rate limiting image pulls from Docker Hub. We're planning a future release with a better
+user interface to work around this. Until then, this is the recommended approach.
 
 ### Sonobuoy Pod
 
-Sonobuoy by default pulls from Docker Hub for [`sonobuoy/sonobuoy` image](https://hub.docker.com/r/sonobuoy/sonobuoy). If you're encountering rate limit on this, you can use VMware-provided mirror with:
+Sonobuoy by default pulls from Docker Hub for [`sonobuoy/sonobuoy` image](https://hub.docker.com/r/sonobuoy/sonobuoy).
+If you're encountering rate limit on this, you can use VMware-provided mirror with:
 
 ```bash
 sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VERSION>
@@ -132,7 +131,8 @@ sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VE
 
 ### Conformance
 
-Kubernetes end-to-end conformance test pulls several images from Docker Hub as part of testing. To override this, you will need to create a registry manifest file locally (e.g. `conformance-image-config.yaml`) containing the following:
+Kubernetes end-to-end conformance test pulls several images from Docker Hub as part of testing. To override this, you
+will need to create a registry manifest file locally (e.g. `conformance-image-config.yaml`) containing the following:
 
 ```yaml
 dockerLibraryRegistry: mirror.gcr.io/library
@@ -144,14 +144,15 @@ Then on running conformance:
 sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VERSION> --e2e-repo-config conformance-image-config.yaml
 ```
 
-Technically `dockerGluster` is also a registry pulling from Docker Hub, but it's not part of Conformance test suite at the moment, so overriding `dockerLibraryRegistry` should be enough.
+Technically `dockerGluster` is also a registry pulling from Docker Hub, but it's not part of Conformance test suite at
+the moment, so overriding `dockerLibraryRegistry` should be enough.
 
 ## Known Issues
 
 ### Leaked End-to-end namespaces
 
-There are some Kubernetes e2e tests that may leak resources. Sonobuoy can
-help clean those up as well by deleting all namespaces prefixed with `e2e`:
+There are some Kubernetes e2e tests that may leak resources. Sonobuoy can help clean those up as well by deleting all
+namespaces prefixed with `e2e`:
 
 ```bash
 sonobuoy delete --all
@@ -159,54 +160,87 @@ sonobuoy delete --all
 
 ### Run on Google Cloud Platform (GCP)
 
-Sonobuoy requires admin permissions which won't be automatic if you are running via Google Kubernetes Engine (GKE) cluster. You must first create an admin role for the user under which you run Sonobuoy:
+Sonobuoy requires admin permissions which won't be automatic if you are running via Google Kubernetes Engine (GKE)
+cluster. You must first create an admin role for the user under which you run Sonobuoy:
 
 ```bash
 kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org>
 ```
 
+### Run on Kubernetes for Docker Desktop
+
+We don't recommend running via a cluster set up via Docker Desktop. Known issues include:
+
+- `kubectl logs` will not function
+- `sonobuoy logs` will not function
+- `sonobuoy retrieve` will not function
+- `systemd-logs` plugin will hang
+
+Most of these issues revolve around issues with kube-proxy on Docker Desktop so if you know of how to resolve these
+issues, let us know.
+
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more
+details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 
-Thanks for taking the time to join our community and start contributing! We
-welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
+Thanks for taking the time to join our community and start contributing! We welcome pull requests. Feel free to dig
+through the [issues][issue] and jump in.
 
 ### Before you start
 
-* Please familiarize yourself with the [Code of Conduct][coc] before
-  contributing.
-* See [CONTRIBUTING.md][contrib] for instructions on the developer certificate
-  of origin that we require.
-* There is a [Slack channel][slack] if you want to
-  interact with other members of the community
+* Please familiarize yourself with the [Code of Conduct][coc] before contributing.
+* See [CONTRIBUTING.md][contrib] for instructions on the developer certificate of origin that we require.
+* There is a [Slack channel][slack] if you want to interact with other members of the community
 
 ## Changelog
 
 See [the list of releases][releases] to find out about feature changes.
 
 [decoupling-sonobuoy-k8s]: https://sonobuoy.io/decoupling-sonobuoy-and-kubernetes
+
 [airgap]: https://sonobuoy.io/docs/airgap
+
 [brew]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos
+
 [cncf]: https://github.com/cncf/k8s-conformance#certified-kubernetes
+
 [coc]: https://github.com/vmware-tanzu/sonobuoy/blob/main/CODE_OF_CONDUCT.md
+
 [contrib]: https://github.com/vmware-tanzu/sonobuoy/blob/main/CONTRIBUTING.md
+
 [docker]: https://docs.docker.com/get-docker/
+
 [docs]: https://sonobuoy.io/docs
+
 [e2ePlugin]: https://sonobuoy.io/docs/e2eplugin
+
 [customPlugins]: https://sonobuoy.io/docs/plugins
+
 [gen]: https://sonobuoy.io/docs/gen
+
 [issue]: https://github.com/vmware-tanzu/sonobuoy/issues
+
 [issue1388]: https://sonobuoy.io/docs/issue1388
+
 [k8s]: https://github.com/kubernetes/kubernetes
+
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
+
 [oview]: https://youtu.be/8QK-Hg2yUd4
+
 [plugins]: https://sonobuoy.io/docs/plugins
+
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
+
 [releases]: https://github.com/vmware-tanzu/sonobuoy/releases
+
 [results]: https://sonobuoy.io/docs/results
+
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
+
 [snapshot]:https://sonobuoy.io/docs/snapshot
+
 [sonobuoyconfig]: https://sonobuoy.io/docs/sonobuoy-config

--- a/site/content/docs/main/_index.md
+++ b/site/content/docs/main/_index.md
@@ -11,36 +11,34 @@ cascade:
 
 ## [Overview][oview]
 
-Sonobuoy is a diagnostic tool that makes it easier to understand the
-state of a Kubernetes cluster by running a set of plugins (including [Kubernetes][k8s] conformance
-tests) in an accessible and non-destructive manner. It is a customizable,
-extendable, and cluster-agnostic way to generate clear, informative reports
-about your cluster.
+Sonobuoy is a diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of
+plugins (including [Kubernetes][k8s] conformance tests) in an accessible and non-destructive manner. It is a
+customizable, extendable, and cluster-agnostic way to generate clear, informative reports about your cluster.
 
-Its selective data dumps of Kubernetes resource objects and cluster nodes allow
-for the following use cases:
+Its selective data dumps of Kubernetes resource objects and cluster nodes allow for the following use cases:
 
 * Integrated end-to-end (e2e) [conformance-testing][e2ePlugin]
 * Workload debugging
 * Custom data collection via extensible plugins
 
-Starting v0.20, Sonobuoy supports Kubernetes v1.17 or later.
-Sonobuoy releases will be independent of Kubernetes release, while ensuring that new releases continue to work functionally across different versions of Kubernetes.
-Read more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
+Starting v0.20, Sonobuoy supports Kubernetes v1.17 or later. Sonobuoy releases will be independent of Kubernetes
+release, while ensuring that new releases continue to work functionally across different versions of Kubernetes. Read
+more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
 
 > Note: You can skip this version enforcement by running Sonobuoy with the `--skip-preflight` flag.
 
 ## Prerequisites
 
-* Access to an up-and-running Kubernetes cluster. If you do not have a cluster,
-  we recommend following the [AWS Quickstart for Kubernetes][quickstart] instructions.
+* Access to an up-and-running Kubernetes cluster. If you do not have a cluster, we recommend following
+  the [AWS Quickstart for Kubernetes][quickstart] instructions.
 
 * An admin `kubeconfig` file, and the KUBECONFIG environment variable set.
 
-* For some advanced workflows it may be required to have `kubectl` installed. See [installing via Homebrew (MacOS)][brew] or [building
-  the binary (Linux)][linux].
+* For some advanced workflows it may be required to have `kubectl` installed.
+  See [installing via Homebrew (MacOS)][brew] or [building the binary (Linux)][linux].
 
-* The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed. See [installing Docker][docker].
+* The `sonobuoy images` subcommand requires [Docker](https://www.docker.com) to be installed.
+  See [installing Docker][docker].
 
 ## Installation
 
@@ -69,7 +67,7 @@ Get the results from the plugins (e.g. e2e test results):
 results=$(sonobuoy retrieve)
 ```
 
-Inspect results for test failures.  This will list the number of tests failed and their names:
+Inspect results for test failures. This will list the number of tests failed and their names:
 
 ```bash
 sonobuoy results $results
@@ -79,11 +77,9 @@ sonobuoy results $results
 
 You can also extract the entire contents of the file to get much more [detailed data][snapshot] about your cluster.
 
-Sonobuoy creates a few resources in order to run and expects to run within its
-own namespace.
+Sonobuoy creates a few resources in order to run and expects to run within its own namespace.
 
-Deleting Sonobuoy entails removing its namespace as well as a few cluster
-scoped resources.
+Deleting Sonobuoy entails removing its namespace as well as a few cluster scoped resources.
 
 ```bash
 sonobuoy delete --wait
@@ -93,7 +89,8 @@ sonobuoy delete --wait
 
 ### Other Tests
 
-By default, `sonobuoy run` runs the Kubernetes conformance tests but this can easily be configured. The same plugin that has the conformance tests has all the Kubernetes end-to-end tests which include other tests such as:
+By default, `sonobuoy run` runs the Kubernetes conformance tests but this can easily be configured. The same plugin that
+has the conformance tests has all the Kubernetes end-to-end tests which include other tests such as:
 
 * tests for specific storage features
 * performance tests
@@ -103,7 +100,8 @@ By default, `sonobuoy run` runs the Kubernetes conformance tests but this can ea
 
 To modify which tests you want to run, checkout our page on the [e2e plugin][e2ePlugin].
 
-If you want to run other tests or tools which are not a part of the Kubernetes end-to-end suite, refer to our documentation on [custom plugins][customPlugins].
+If you want to run other tests or tools which are not a part of the Kubernetes end-to-end suite, refer to our
+documentation on [custom plugins][customPlugins].
 
 ### Monitoring Sonobuoy during a run
 
@@ -121,16 +119,17 @@ sonobuoy logs
 
 ## Troubleshooting
 
-If you encounter any problems that the documentation does not address, [file an
-issue][issue].
+If you encounter any problems that the documentation does not address, [file an issue][issue].
 
 ## Docker Hub rate limit
 
-This year, Docker has started rate limiting image pulls from Docker Hub. We're planning a future release with a better user interface to work around this. Until then, this is the recommended approach.
+This year, Docker has started rate limiting image pulls from Docker Hub. We're planning a future release with a better
+user interface to work around this. Until then, this is the recommended approach.
 
 ### Sonobuoy Pod
 
-Sonobuoy by default pulls from Docker Hub for [`sonobuoy/sonobuoy` image](https://hub.docker.com/r/sonobuoy/sonobuoy). If you're encountering rate limit on this, you can use VMware-provided mirror with:
+Sonobuoy by default pulls from Docker Hub for [`sonobuoy/sonobuoy` image](https://hub.docker.com/r/sonobuoy/sonobuoy).
+If you're encountering rate limit on this, you can use VMware-provided mirror with:
 
 ```bash
 sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VERSION>
@@ -138,7 +137,8 @@ sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VE
 
 ### Conformance
 
-Kubernetes end-to-end conformance test pulls several images from Docker Hub as part of testing. To override this, you will need to create a registry manifest file locally (e.g. `conformance-image-config.yaml`) containing the following:
+Kubernetes end-to-end conformance test pulls several images from Docker Hub as part of testing. To override this, you
+will need to create a registry manifest file locally (e.g. `conformance-image-config.yaml`) containing the following:
 
 ```yaml
 dockerLibraryRegistry: mirror.gcr.io/library
@@ -150,14 +150,15 @@ Then on running conformance:
 sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:<VERSION> --e2e-repo-config conformance-image-config.yaml
 ```
 
-Technically `dockerGluster` is also a registry pulling from Docker Hub, but it's not part of Conformance test suite at the moment, so overriding `dockerLibraryRegistry` should be enough.
+Technically `dockerGluster` is also a registry pulling from Docker Hub, but it's not part of Conformance test suite at
+the moment, so overriding `dockerLibraryRegistry` should be enough.
 
 ## Known Issues
 
 ### Leaked End-to-end namespaces
 
-There are some Kubernetes e2e tests that may leak resources. Sonobuoy can
-help clean those up as well by deleting all namespaces prefixed with `e2e`:
+There are some Kubernetes e2e tests that may leak resources. Sonobuoy can help clean those up as well by deleting all
+namespaces prefixed with `e2e`:
 
 ```bash
 sonobuoy delete --all
@@ -165,54 +166,87 @@ sonobuoy delete --all
 
 ### Run on Google Cloud Platform (GCP)
 
-Sonobuoy requires admin permissions which won't be automatic if you are running via Google Kubernetes Engine (GKE) cluster. You must first create an admin role for the user under which you run Sonobuoy:
+Sonobuoy requires admin permissions which won't be automatic if you are running via Google Kubernetes Engine (GKE)
+cluster. You must first create an admin role for the user under which you run Sonobuoy:
 
 ```bash
 kubectl create clusterrolebinding <your-user-cluster-admin-binding> --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org>
 ```
 
+### Run on Kubernetes for Docker Desktop
+
+We don't recommend running via a cluster set up via Docker Desktop. Known issues include:
+
+- `kubectl logs` will not function
+- `sonobuoy logs` will not function
+- `sonobuoy retrieve` will not function
+- `systemd-logs` plugin will hang
+
+Most of these issues revolve around issues with kube-proxy on Docker Desktop so if you know of how to resolve these
+issues, let us know.
+
 ### Certified-Conformance bug (versions v0.53.0 and v0.53.1)
 
-These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
+These versions of Sonobuoy have a bug that runs the wrong set of tests without additional actions. See more
+details [here][issue1388]. The simplest way to avoid this is to update your version of Sonobuoy to >= v0.53.2.
 
 ## Contributing
 
-Thanks for taking the time to join our community and start contributing! We
-welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
+Thanks for taking the time to join our community and start contributing! We welcome pull requests. Feel free to dig
+through the [issues][issue] and jump in.
 
 ### Before you start
 
-* Please familiarize yourself with the [Code of Conduct][coc] before
-  contributing.
-* See [CONTRIBUTING.md][contrib] for instructions on the developer certificate
-  of origin that we require.
-* There is a [Slack channel][slack] if you want to
-  interact with other members of the community
+* Please familiarize yourself with the [Code of Conduct][coc] before contributing.
+* See [CONTRIBUTING.md][contrib] for instructions on the developer certificate of origin that we require.
+* There is a [Slack channel][slack] if you want to interact with other members of the community
 
 ## Changelog
 
 See [the list of releases][releases] to find out about feature changes.
 
 [decoupling-sonobuoy-k8s]: https://sonobuoy.io/decoupling-sonobuoy-and-kubernetes
+
 [airgap]: airgap
+
 [brew]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos
+
 [cncf]: https://github.com/cncf/k8s-conformance#certified-kubernetes
+
 [coc]: https://github.com/vmware-tanzu/sonobuoy/blob/main/CODE_OF_CONDUCT.md
-[contrib]: https://github.com/vmware-tanzu/sonobuoy/blob/masmainter/CONTRIBUTING.md
+
+[contrib]: https://github.com/vmware-tanzu/sonobuoy/blob/main/CONTRIBUTING.md
+
 [docker]: https://docs.docker.com/get-docker/
+
 [docs]: https://sonobuoy.io/docs/main
+
 [e2ePlugin]: e2eplugin
+
 [customPlugins]: plugins
+
 [gen]: gen
+
 [issue]: https://github.com/vmware-tanzu/sonobuoy/issues
+
 [issue1388]: issue1388
+
 [k8s]: https://github.com/kubernetes/kubernetes
+
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
+
 [oview]: https://youtu.be/8QK-Hg2yUd4
+
 [plugins]: plugins
+
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
+
 [releases]: https://github.com/vmware-tanzu/sonobuoy/releases
+
 [results]: results
+
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
+
 [snapshot]:snapshot
+
 [sonobuoyconfig]: sonobuoy-config


### PR DESCRIPTION
Kube-proxy seems to have issues with docker desktop which causes
kubectl logs, sonobuoy logs, and sonobuoy retrieve (and probably
others) to fail. Systemd-logs also fails to run and there is a
separate bug filed to fix its error path (currently hanging instead
of reporting the error).

Fixes #1446

Signed-off-by: John Schnake <jschnake@vmware.com>
