### PR TITLE
Add special config option to skip all plugins

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -130,6 +130,13 @@ func (*SonobuoyClient) GenerateManifestAndPlugins(cfg *GenConfig) ([]byte, []*ma
 		cfg.DynamicPlugins = []string{e2ePluginName, systemdLogsName}
 	}
 
+	// Skip plugins will just remove all plugins. Only added to support a zero-plugin
+	// use case where the user just wants to use Sonobuoy for data gathering.
+	if cfg.Config.SkipPlugins {
+		cfg.DynamicPlugins = nil
+		cfg.StaticPlugins = nil
+	}
+
 	plugins := []*manifest.Manifest{}
 	for _, v := range cfg.DynamicPlugins {
 		switch v {

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -208,6 +208,17 @@ func TestGenerateManifestGolden(t *testing.T) {
 			},
 			goldenFile: filepath.Join("testdata", "default-plugins-via-nil-selection.golden"),
 		}, {
+			name: "Plugins skipped entirely if config specifies",
+			inputcm: &client.GenConfig{
+				Config: fromConfig(func(c *config.Config) *config.Config {
+					c.PluginSelections = []plugin.Selection{}
+					c.SkipPlugins = true
+					return c
+				}),
+				KubeVersion: "v99+static.testing",
+			},
+			goldenFile: filepath.Join("testdata", "no-plugins-via-option.golden"),
+		}, {
 			name: "Manually specify e2e",
 			inputcm: &client.GenConfig{
 				DynamicPlugins: []string{"e2e"},
@@ -418,6 +429,22 @@ func TestGenerateManifestGolden(t *testing.T) {
 				},
 			},
 			goldenFile: filepath.Join("testdata", "plugin-configmaps.golden"),
+		}, {
+			name: "ImagePullPolicy applied to all plugins",
+			inputcm: &client.GenConfig{
+				Config:      staticConfig(),
+				KubeVersion: "v99+static.testing",
+				StaticPlugins: []*manifest.Manifest{
+					{
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin1"},
+						Spec:           manifest.Container{Container: v1.Container{ImagePullPolicy: "Never"}},
+					}, {
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myplugin2"},
+						Spec:           manifest.Container{Container: v1.Container{ImagePullPolicy: "Always"}},
+					},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "imagePullPolicy-all-plugins.golden"),
 		}, {
 			name: "ImagePullPolicy applied to all plugins",
 			inputcm: &client.GenConfig{

--- a/pkg/client/testdata/no-plugins-via-option.golden
+++ b/pkg/client/testdata/no-plugins-via-option.golden
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"static-version-for-testing","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":[],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","SkipPlugins":true,"WorkerImage":"sonobuoy/sonobuoy:static-version-for-testing","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:static-version-for-testing
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    command: ["/sonobuoy"]
+    args: ["aggregator", "--no-exit", "--level=info", "-v=4", "--alsologtostderr"]
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,6 +124,7 @@ type Config struct {
 	PluginSelections []plugin.Selection       `json:"Plugins" mapstructure:"Plugins"`
 	PluginSearchPath []string                 `json:"PluginSearchPath" mapstructure:"PluginSearchPath"`
 	Namespace        string                   `json:"Namespace" mapstructure:"Namespace"`
+	SkipPlugins      bool                     `json:"SkipPlugins,omitempty"`
 	LoadedPlugins    []plugin.Interface       `json:"-"` // this is assigned when plugins are loaded.
 
 	///////////////////////////////////////////////


### PR DESCRIPTION
To support the 0 plugins use case (uses sonobuoy for data
gathering only), this flag is the easiest and most clear approach.

Simply removes the plugins from the configuration before the
marshalling of the plugins. As a result, no plugins are put into
the configmap and none are available for loading on the aggregator
at run time.

Signed-off-by: John Schnake <jschnake@vmware.com>

- Fixes #1504 

**Release note**:
```
Added a `SkipPlugins` option in the Sonobuoy config object which simplifies the situation when you may want to just run Sonobuoy for its data-gathering capability.
```
