### PR TITLE
Add flag for specifying the aggregator path to retrieve

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -49,6 +49,7 @@ const (
 	e2eRegistryConfigFlag   = "e2e-repo-config"
 	pluginImageFlag         = "plugin-image"
 	filenameFlag            = "filename"
+	retrievePathFlag        = "retrieve-path"
 	securityContextModeFlag = "security-context-mode"
 
 	// Quick runs a single E2E test and the systemd log tests.
@@ -424,6 +425,14 @@ func AddFilenameFlag(str *string, flags *pflag.FlagSet) {
 	flags.StringVarP(
 		str, filenameFlag, "f", "",
 		"Specify the name of the downloaded file. If empty, defaults to the name of the tarball in the pod.",
+	)
+}
+
+// AddRetrievePathFlag initialises a namespace flag.
+func AddRetrievePathFlag(str *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		str, retrievePathFlag, config.AggregatorResultsPath,
+		"Specify the path to retrieve from the aggregator pod.",
 	)
 }
 

--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -39,6 +39,7 @@ type retrieveFlags struct {
 	extract        bool
 	outputLocation string
 	filename       string
+	aggregatorPath string
 }
 
 func NewCmdRetrieve() *cobra.Command {
@@ -54,6 +55,7 @@ func NewCmdRetrieve() *cobra.Command {
 	AddNamespaceFlag(&rcvFlags.namespace, cmd.Flags())
 	AddExtractFlag(&rcvFlags.extract, cmd.Flags())
 	AddFilenameFlag(&rcvFlags.filename, cmd.Flags())
+	AddRetrievePathFlag(&rcvFlags.aggregatorPath, cmd.Flags())
 
 	return cmd
 }
@@ -72,7 +74,10 @@ func retrieveResultsCmd(opts *retrieveFlags) func(cmd *cobra.Command, args []str
 		}
 
 		// Get a reader that contains the tar output of the results directory.
-		reader, ec, err := sbc.RetrieveResults(&client.RetrieveConfig{Namespace: opts.namespace})
+		reader, ec, err := sbc.RetrieveResults(&client.RetrieveConfig{
+			Namespace: opts.namespace,
+			Path:      opts.aggregatorPath,
+		})
 		if err != nil {
 			errlog.LogError(err)
 			os.Exit(1)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -189,6 +189,9 @@ func (dc *DeleteConfig) Validate() error {
 type RetrieveConfig struct {
 	// Namespace is the namespace the sonobuoy aggregator is running in.
 	Namespace string
+	// Path is the location that the aggregator stores results in. Should
+	// usually be the same value but can help with debugging some issues.
+	Path string
 }
 
 // Validate checks the config to determine if it is valid.


### PR DESCRIPTION
This allows us to debug/avoid one of the common bugs we've seen
lately related to poor handling of the aggregator results directory
and the config results directory.

Signed-off-by: John Schnake <jschnake@vmware.com>