### PR TITLE
Add ci-lint options

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -9,6 +9,9 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.31
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=2m0s -v
   bash-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Multiple branches time out now and it wasn't clear if we really
wanted/needed the cache at all or if it caused more problems too.

- Extending timeout
- verbose mode
- disables cache

Signed-off-by: John Schnake <jschnake@vmware.com>
