### PR TITLE
Add more warnings for flag interactions

### DIFF
--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -101,9 +101,17 @@ func prerunChecks(cmd *cobra.Command, args []string) error {
 	logrus.Tracef("Invoked command %v with args %v and flags %v", cmd.Name(), args, flagsDebug)
 
 	// Difficult to do checks like this within the flag themselves (since they dont know
-	// about each other).
+	// about each other). Splitting up checks into varous 'ifs' for ease of reading/writing even if not most succinct.
 	if flagsSet["mode"] && (flagsSet["e2e-focus"] || flagsSet["e2e-skip"]) {
-		logrus.Warnf("mode flag and e2e-focus/skip flags both set and may collide")
+		logrus.Warnf("mode flag and e2e-focus/skip flags both provided and may cause unintended behavior")
+	}
+
+	if flagsSet["rerun-failed"] && (flagsSet["e2e-focus"] || flagsSet["e2e-skip"]) {
+		logrus.Warnf("rerun-failed flag and e2e-focus/skip flags both provided and may cause unintended behavior")
+	}
+
+	if flagsSet["rerun-failed"] && flagsSet["mode"] {
+		logrus.Warnf("rerun-failed flag and mode flags both provided and may cause unintended behavior")
 	}
 
 	if flagsSet["kube-conformance-image"] && (flagsSet["kubernetes-version"] || flagsSet["kube-conformance-image-version"]) {

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -636,6 +636,14 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			desc:       "allow plugin renaming",
 			cmdLine:    "gen -p testdata/hello-world.yaml@goodbye -p testImage/yaml/job-junit-passing-singlefile.yaml@customname --kubernetes-version=ignore",
 			expectFile: "testdata/gen-plugin-renaming.golden",
+		}, {
+			desc:       "warning given if mode/focus/skip set together ",
+			cmdLine:    "gen --mode=certified-conformance --e2e-focus=foo --kubernetes-version=ignore",
+			expectFile: "testdata/gen-mode-and-focus.golden",
+		}, {
+			desc:       "warning given if rerun-failed set withother mode/focus/skip flags",
+			cmdLine:    "gen --rerun-failed testdata/results-4-e2e-failures.tar.gz --mode=certified-conformance --kubernetes-version=ignore",
+			expectFile: "testdata/gen-mode-and-rerun.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-mode-and-focus.golden
+++ b/test/integration/testdata/gen-mode-and-focus.golden
@@ -1,0 +1,242 @@
+time="STATIC_TIME_FOR_TESTING" level=warning msg="mode flag and e2e-focus/skip flags both provided and may cause unintended behavior"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount-sonobuoy
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '/metrics'
+  - '/logs'
+  - '/logs/*'
+  verbs:
+  - 'get'
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_EXTRA_ARGS
+        value: --progress-report-url=http://localhost:8099/progress
+      - name: E2E_FOCUS
+        value: foo
+      - name: E2E_PARALLEL
+        value: "false"
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: k8s.gcr.io/conformance:ignore
+      imagePullPolicy: IfNotPresent
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+  plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-format: raw
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: sonobuoy/systemd-logs:v0.4
+      imagePullPolicy: IfNotPresent
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /node
+        name: root
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:*STATIC_FOR_TESTING*
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    command: ["/sonobuoy"]
+    args: ["aggregator", "--no-exit", "--level=info", "-v=4", "--alsologtostderr"]
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP
+

--- a/test/integration/testdata/gen-mode-and-rerun.golden
+++ b/test/integration/testdata/gen-mode-and-rerun.golden
@@ -1,0 +1,242 @@
+time="STATIC_TIME_FOR_TESTING" level=warning msg="rerun-failed flag and mode flags both provided and may cause unintended behavior"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount-sonobuoy
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '/metrics'
+  - '/logs'
+  - '/logs/*'
+  verbs:
+  - 'get'
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_EXTRA_ARGS
+        value: --progress-report-url=http://localhost:8099/progress
+      - name: E2E_FOCUS
+        value: \[Conformance\]
+      - name: E2E_PARALLEL
+        value: "false"
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: k8s.gcr.io/conformance:ignore
+      imagePullPolicy: IfNotPresent
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+  plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-format: raw
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh; while true; do echo "Plugin is complete. Sleeping indefinitely
+        to avoid container exit and automatic restarts from Kubernetes"; sleep 3600; done
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: sonobuoy/systemd-logs:v0.4
+      imagePullPolicy: IfNotPresent
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /node
+        name: root
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:*STATIC_FOR_TESTING*
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    command: ["/sonobuoy"]
+    args: ["aggregator", "--no-exit", "--level=info", "-v=4", "--alsologtostderr"]
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP
+


### PR DESCRIPTION
The rerun-failed flag also modifies the focus/skip fields and
so it can conflict if both are set. Warn users so they realize the
issue.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1515

**Release note**:
```
Added warning if you specify rerun-failed along with other flags that modify the focus/skip of the e2e plugin.
```
