### PR TITLE
Export junitResults type

### DIFF
--- a/pkg/client/results/junit.go
+++ b/pkg/client/results/junit.go
@@ -42,20 +42,20 @@ const (
 	JUnitErrorKey = "error"
 )
 
-// junitResult is a wrapper around the suite[s] which enable results to
+// JUnitResult is a wrapper around the suite[s] which enable results to
 // be either a single suite or a collection of suites. For instance,
 // e2e tests (which use the onsi/ginkgo reporter) report a single, top-level
 // testsuite whereas other tools report a top-level testsuites object
 // which may have 1+ testsuite children. Only one of the fields should be
 // set, not both.
-type junitResult struct {
+type JUnitResult struct {
 	suites JUnitTestSuites
 }
 
 // UnmarshalXML will unmarshal the document into either the 'Suites'
 // field of the JUnitResult. If a single testsuite is found (instead of a testsuites object)
 // it is unmarshalled and then added into the set of JUnitResult.Suites.Suites
-func (j *junitResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (j *JUnitResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var returnErr error
 	if start.Name.Local == "testsuites" {
 		returnErr = d.DecodeElement(&j.suites, &start)
@@ -220,7 +220,7 @@ func junitProcessReader(r io.Reader, name string, metadata map[string]string) (I
 	}
 
 	decoder := xml.NewDecoder(r)
-	junitResults := junitResult{}
+	junitResults := JUnitResult{}
 	if err := decoder.Decode(&junitResults); err != nil {
 		rootItem.Status = StatusUnknown
 		if rootItem.Metadata == nil {

--- a/pkg/client/results/junit_test.go
+++ b/pkg/client/results/junit_test.go
@@ -123,12 +123,12 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 	tcs := []struct {
 		desc   string
 		input  string
-		expect junitResult
+		expect JUnitResult
 	}{
 		{
 			desc:  "top-level testsuites",
 			input: `<testsuites><testsuite name="testsuite1"></testsuite><testsuite name="testsuite2"></testsuite></testsuites>`,
-			expect: junitResult{
+			expect: JUnitResult{
 				suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite1"},
@@ -139,7 +139,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 		}, {
 			desc:  "top-level testsuite",
 			input: `<testsuite name="testsuite1"></testsuite>`,
-			expect: junitResult{
+			expect: JUnitResult{
 				suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite1"},
@@ -149,7 +149,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 		}, {
 			desc:  "Empty testsuite name gets filled with unique values",
 			input: `<testsuite></testsuite>`,
-			expect: junitResult{
+			expect: JUnitResult{
 				suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite-001"},
@@ -159,7 +159,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 		}, {
 			desc:  "Empty testsuite names get filled with unique values",
 			input: `<testsuites><testsuite></testsuite><testsuite></testsuite></testsuites>`,
-			expect: junitResult{
+			expect: JUnitResult{
 				suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite-001"},
@@ -172,7 +172,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			out := junitResult{}
+			out := JUnitResult{}
 			err := xml.Unmarshal([]byte(tc.input), &out)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Working on a postprocessor to handle junit files and it would
be a shame to not be able to reuse whats here already.

I think just the types and unmarshal code is needed but this may extend
a bit if necessary to avoid too much copy/paste.

Signed-off-by: John Schnake <jschnake@vmware.com>

\