### PR TITLE
Export field

### DIFF
--- a/pkg/client/results/item.go
+++ b/pkg/client/results/item.go
@@ -48,7 +48,7 @@ const (
 	PostProcessedResultsFile = "sonobuoy_results.yaml"
 
 	// MetadataFileKey is the key used in an Item's metadata field when the Item is
-	// representing the a file summary (and its leaf nodes are individual tests or suites).
+	// representing the a file summary (and its leaf nodes are individual tests or Suites).
 	MetadataFileKey = "file"
 
 	// MetadataTypeKey is the key used in an Item's metadata field when describing what type

--- a/pkg/client/results/junit.go
+++ b/pkg/client/results/junit.go
@@ -49,7 +49,7 @@ const (
 // which may have 1+ testsuite children. Only one of the fields should be
 // set, not both.
 type JUnitResult struct {
-	suites JUnitTestSuites
+	Suites JUnitTestSuites
 }
 
 // UnmarshalXML will unmarshal the document into either the 'Suites'
@@ -58,15 +58,15 @@ type JUnitResult struct {
 func (j *JUnitResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var returnErr error
 	if start.Name.Local == "testsuites" {
-		returnErr = d.DecodeElement(&j.suites, &start)
+		returnErr = d.DecodeElement(&j.Suites, &start)
 	} else {
 		var s JUnitTestSuite
 		returnErr = d.DecodeElement(&s, &start)
-		j.suites = JUnitTestSuites{Suites: []JUnitTestSuite{s}}
+		j.Suites = JUnitTestSuites{Suites: []JUnitTestSuite{s}}
 	}
-	for i := range j.suites.Suites {
-		if j.suites.Suites[i].Name == "" {
-			j.suites.Suites[i].Name = fmt.Sprintf("testsuite-%03d", i+1)
+	for i := range j.Suites.Suites {
+		if j.Suites.Suites[i].Name == "" {
+			j.Suites.Suites[i].Name = fmt.Sprintf("testsuite-%03d", i+1)
 		}
 	}
 	return returnErr
@@ -230,7 +230,7 @@ func junitProcessReader(r io.Reader, name string, metadata map[string]string) (I
 		return rootItem, errors.Wrap(err, "decoding junit")
 	}
 
-	for _, ts := range junitResults.suites.Suites {
+	for _, ts := range junitResults.Suites.Suites {
 		suiteItem := Item{
 			Name:   ts.Name,
 			Status: StatusPassed,

--- a/pkg/client/results/junit_test.go
+++ b/pkg/client/results/junit_test.go
@@ -129,7 +129,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 			desc:  "top-level testsuites",
 			input: `<testsuites><testsuite name="testsuite1"></testsuite><testsuite name="testsuite2"></testsuite></testsuites>`,
 			expect: JUnitResult{
-				suites: JUnitTestSuites{
+				Suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite1"},
 						{Name: "testsuite2"},
@@ -140,7 +140,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 			desc:  "top-level testsuite",
 			input: `<testsuite name="testsuite1"></testsuite>`,
 			expect: JUnitResult{
-				suites: JUnitTestSuites{
+				Suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite1"},
 					},
@@ -150,7 +150,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 			desc:  "Empty testsuite name gets filled with unique values",
 			input: `<testsuite></testsuite>`,
 			expect: JUnitResult{
-				suites: JUnitTestSuites{
+				Suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite-001"},
 					},
@@ -160,7 +160,7 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 			desc:  "Empty testsuite names get filled with unique values",
 			input: `<testsuites><testsuite></testsuite><testsuite></testsuite></testsuites>`,
 			expect: JUnitResult{
-				suites: JUnitTestSuites{
+				Suites: JUnitTestSuites{
 					Suites: []JUnitTestSuite{
 						{Name: "testsuite-001"},
 						{Name: "testsuite-002"},
@@ -180,9 +180,9 @@ func TestJUnitResult_UnmarshalXML(t *testing.T) {
 
 			// XMLName fields complicate the comparison since it is set during
 			// deserialization. Unset all those values before comparing.
-			out.suites.XMLName = xml.Name{}
-			for i := range out.suites.Suites {
-				out.suites.Suites[i].XMLName = xml.Name{}
+			out.Suites.XMLName = xml.Name{}
+			for i := range out.Suites.Suites {
+				out.Suites.Suites[i].XMLName = xml.Name{}
 			}
 
 			if diff := pretty.Compare(out, tc.expect); diff != "" {


### PR DESCRIPTION
Working on a postprocessor to handle junit files and it would
be a shame to not be able to reuse whats here already.

I think just the types and unmarshal code is needed but this may extend
a bit if necessary to avoid too much copy/paste.

Field needed to be exported as well.
Signed-off-by: John Schnake <jschnake@vmware.com>
