### PR TITLE
Fix index bug in gen logic

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -291,11 +291,11 @@ func applyEnvOverrides(pluginEnvOverrides map[string]map[string]string, plugins 
 // autoAttachResultsDir will either add the volumemount for the results dir or modify the existing
 // one to have the right path set.
 func autoAttachResultsDir(plugins []*manifest.Manifest, resultsDir string) {
-	for i := range plugins {
-		containers := []*corev1.Container{&plugins[i].Spec.Container}
-		if plugins[i].PodSpec != nil {
-			for i := range plugins[i].PodSpec.Containers {
-				containers = append(containers, &plugins[i].PodSpec.Containers[i])
+	for pluginIndex := range plugins {
+		containers := []*corev1.Container{&plugins[pluginIndex].Spec.Container}
+		if plugins[pluginIndex].PodSpec != nil {
+			for containerIndex := range plugins[pluginIndex].PodSpec.Containers {
+				containers = append(containers, &plugins[pluginIndex].PodSpec.Containers[containerIndex])
 			}
 		}
 		addOrUpdateResultsMount(resultsDir, containers...)

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -649,6 +649,10 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			desc:       "warning given if rerun-failed set withother mode/focus/skip flags",
 			cmdLine:    "gen --rerun-failed testdata/results-4-e2e-failures.tar.gz --mode=certified-conformance --kubernetes-version=ignore",
 			expectFile: "testdata/gen-mode-and-rerun.golden",
+		}, {
+			desc:       "multiple plugins and multiple containers issue 1528",
+			cmdLine:    "gen -p testdata/plugins/good/sidecar.yaml -p testdata/plugins/good/hello-world.yaml --kubernetes-version=ignore",
+			expectFile: "testdata/gen-issue-1528.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-issue-1528.golden
+++ b/test/integration/testdata/gen-issue-1528.golden
@@ -1,0 +1,215 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount-sonobuoy
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '/metrics'
+  - '/logs'
+  - '/logs/*'
+  verbs:
+  - 'get'
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","AggregatorPermissions":"clusterAdmin","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      description: This is a plugin description.
+      driver: Job
+      plugin-name: hello-world
+      result-format: raw
+      source-url: foo.com
+    spec:
+      command:
+      - ./run.sh
+      env:
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: hello:v9
+      imagePullPolicy: IfNotPresent
+      name: plugin
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+  plugin-1.yaml: |
+    podSpec:
+      containers:
+      - env:
+        - name: RESULTS_DIR
+          value: /tmp/sonobuoy/results
+        - name: SONOBUOY
+          value: "true"
+        - name: SONOBUOY_CONFIG_DIR
+          value: /tmp/sonobuoy/config
+        - name: SONOBUOY_K8S_VERSION
+          value: ignore
+        - name: SONOBUOY_PROGRESS_PORT
+          value: "8099"
+        - name: SONOBUOY_RESULTS_DIR
+          value: /tmp/sonobuoy/results
+        image: foo/baz:0.1.2
+        imagePullPolicy: Always
+        name: sidecar
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp/sonobuoy/results
+          name: results
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+    sonobuoy-config:
+      driver: Job
+      plugin-name: sidecarplugin
+      result-format: junit
+    spec:
+      env:
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: foo/bar:0.1.2
+      imagePullPolicy: IfNotPresent
+      name: plugin
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  containers:
+  - env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:*STATIC_FOR_TESTING*
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    command: ["/sonobuoy"]
+    args: ["aggregator", "--no-exit", "--level=info", "-v=4", "--alsologtostderr"]
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP
+

--- a/test/integration/testdata/plugin-list.golden
+++ b/test/integration/testdata/plugin-list.golden
@@ -9,3 +9,9 @@ Filename: testdata/plugins/good/hw-2.yaml
 Plugin name (in aggregator): hello-world2
 Source URL: 
 Description: 
+---
+Run as: sidecar
+Filename: testdata/plugins/good/sidecar.yaml
+Plugin name (in aggregator): sidecarplugin
+Source URL: 
+Description: 

--- a/test/integration/testdata/plugins/good/sidecar.yaml
+++ b/test/integration/testdata/plugins/good/sidecar.yaml
@@ -1,0 +1,19 @@
+podSpec:
+  containers:
+    - name: sidecar
+      image: foo/baz:0.1.2
+      imagePullPolicy: Always
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+sonobuoy-config:
+  driver: Job
+  plugin-name: sidecarplugin
+  result-format: junit
+spec:
+  image: foo/bar:0.1.2
+  imagePullPolicy: Always
+  name: plugin
+  resources: {}
+  volumes:
+  - name: results
+    emptyDir: {}


### PR DESCRIPTION
If you are running two plugins but one has a sidecar and the other doesnt,
a bad re-use of an index caused an out of bounds reference.

 - Fixes bug by renaming index in each case
 - Adds test to prevent regression

Fixes #1528

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Fixes a bug where `sonobuoy gen` would panic in some situations where plugins varied in whether or not they had sidecar containers.
```
