### PR TITLE
Allow custom donefile

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,6 +139,9 @@ type Config struct {
 	CustomAnnotations     map[string]string `json:"CustomAnnotations,omitempty" mapstructure:"CustomAnnotations"`
 	AggregatorPermissions string            `json:"AggregatorPermissions" mapstructure:"AggregatorPermissions"`
 
+	// DoneFile is the file which the worker will wait for (and read) to determine and to submit the results (path is in the file).
+	DoneFile string `json:"DoneFile,omitempty" mapstructure:"DoneFile"`
+
 	// ProgressUpdatesPort is the port on which the Sonobuoy worker will listen for status updates from its plugin.
 	ProgressUpdatesPort string `json:"ProgressUpdatesPort,omitempty" mapstructure:"ProgressUpdatesPort"`
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -149,7 +149,7 @@ func Run(restConf *rest.Config, cfg *config.Config) (errCount int) {
 	}
 
 	// 4. Run the plugin aggregator. Save this error for clear logging later.
-	runErr := pluginaggregation.Run(kubeClient, cfg.LoadedPlugins, cfg.Aggregation, cfg.ProgressUpdatesPort, cfg.ResultsDir, cfg.Namespace, outpath)
+	runErr := pluginaggregation.Run(kubeClient, cfg.LoadedPlugins, cfg.Aggregation, cfg.ProgressUpdatesPort, cfg.ResultsDir, cfg.Namespace, outpath, cfg.DoneFile)
 	trackErrorsFor("running plugins")(runErr)
 
 	// 5. Run the queries

--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -152,7 +152,7 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 			}
 
 			go func() {
-				a.RunAndMonitorPlugin(ctx, testTimeout, tc.plugin, fclient, nil, "testname", testCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+				a.RunAndMonitorPlugin(ctx, testTimeout, tc.plugin, fclient, nil, "testname", testCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 				doneCh <- struct{}{}
 			}()
 
@@ -206,7 +206,7 @@ type MockCleanupPlugin struct {
 	cleanedUp   bool
 }
 
-func (cp *MockCleanupPlugin) Run(_ kubernetes.Interface, _ string, _ *tls.Certificate, _ *corev1.Pod, _, _ string) error {
+func (cp *MockCleanupPlugin) Run(_ kubernetes.Interface, _ string, _ *tls.Certificate, _ *corev1.Pod, _, _, _ string) error {
 	return nil
 }
 

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -239,8 +239,8 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate, progres
 	return envVars
 }
 
-// CreateWorkerContainerDefintion creates the container definition to run the Sonobuoy worker for a plugin.
-func (b *Base) CreateWorkerContainerDefintion(hostname string, cert *tls.Certificate, command, args []string, progressPort, resultDir string) v1.Container {
+// CreateWorkerContainerDefinition creates the container definition to run the Sonobuoy worker for a plugin.
+func (b *Base) CreateWorkerContainerDefinition(hostname string, cert *tls.Certificate, command, args []string, progressPort, resultDir string) v1.Container {
 	container := v1.Container{
 		Name:            "sonobuoy-worker",
 		Image:           b.SonobuoyImage,

--- a/pkg/plugin/driver/base_test.go
+++ b/pkg/plugin/driver/base_test.go
@@ -155,7 +155,7 @@ func TestCreateWorkerContainerDefinition(t *testing.T) {
 		SessionID:       "sessionID",
 	}
 
-	wc := b.CreateWorkerContainerDefintion(aggregatorURL, cert, command, args, "", "/tmp/sonobuoy/results")
+	wc := b.CreateWorkerContainerDefinition(aggregatorURL, cert, command, args, "", "/tmp/sonobuoy/results")
 
 	checkFields := func(container v1.Container) error {
 		if container.Name != "sonobuoy-worker" {

--- a/pkg/plugin/driver/daemonset/daemonset_test.go
+++ b/pkg/plugin/driver/daemonset/daemonset_test.go
@@ -104,7 +104,7 @@ func TestCreateDaemonSetDefintion(t *testing.T) {
 		t.Fatalf("couldn't make client certificate %v", err)
 	}
 
-	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 
 	expectedName := fmt.Sprintf("sonobuoy-%v-daemon-set-%v", pluginName, testDaemonSet.SessionID)
 	if daemonSet.Name != expectedName {
@@ -205,7 +205,7 @@ func TestCreateDaemonSetDefintionUsesDefaultPodSpec(t *testing.T) {
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 	podSpec := daemonSet.Spec.Template.Spec
 
 	expectedServiceAccount := "sonobuoy-serviceaccount"
@@ -246,7 +246,7 @@ func TestCreateDaemonSetDefintionUsesProvidedPodSpec(t *testing.T) {
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	daemonSet := testDaemonSet.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 	podSpec := daemonSet.Spec.Template.Spec
 
 	if podSpec.ServiceAccountName != expectedServiceAccountName {
@@ -281,7 +281,7 @@ func TestCreateDaemonSetDefinitionAddsToExistingResourcesInPodSpec(t *testing.T)
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	daemonSet := testPlugin.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	daemonSet := testPlugin.createDaemonSetDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 	podSpec := daemonSet.Spec.Template.Spec
 
 	// Existing container in pod spec, plus 2 added by Sonobuoy
@@ -328,7 +328,7 @@ func TestCreateDaemonSetDefinitionSetsOwnerReference(t *testing.T) {
 		},
 	}
 
-	daemonSet := testPlugin.createDaemonSetDefinition("", clientCert, &aggregatorPod, "", "/tmp/sonobuoy/results")
+	daemonSet := testPlugin.createDaemonSetDefinition("", clientCert, &aggregatorPod, "", "/tmp/sonobuoy/results", "done")
 	ownerReferences := daemonSet.ObjectMeta.OwnerReferences
 
 	if len(ownerReferences) != 1 {

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -75,7 +75,7 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	}
 }
 
-func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir string) v1.Pod {
+func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir, doneFile string) v1.Pod {
 	pod := v1.Pod{}
 	annotations := map[string]string{
 		"sonobuoy-driver": p.GetDriver(),
@@ -116,7 +116,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "--level=trace", "-v=6", "--logtostderr"}, progressPort, resultDir),
+		p.CreateWorkerContainerDefinition(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "--level=trace", "-v=6", "--logtostderr", fmt.Sprintf("--done-file=%v", doneFile)}, progressPort, resultDir),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {
@@ -141,8 +141,8 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 }
 
 // Run dispatches worker pods according to the Job's configuration.
-func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir string) error {
-	job := p.createPodDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod, progressPort, resultDir)
+func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir, doneFile string) error {
+	job := p.createPodDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod, progressPort, resultDir, doneFile)
 
 	secret, err := p.MakeTLSSecret(cert, ownerPod)
 	if err != nil {

--- a/pkg/plugin/driver/job/job_test.go
+++ b/pkg/plugin/driver/job/job_test.go
@@ -103,7 +103,7 @@ func TestCreatePodDefinition(t *testing.T) {
 		t.Fatalf("couldn't make client certificate %v", err)
 	}
 
-	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 
 	expectedName := fmt.Sprintf("sonobuoy-%v-job-%v", pluginName, testPlugin.SessionID)
 	if pod.Name != expectedName {
@@ -198,7 +198,7 @@ func TestCreatePodDefinitionUsesDefaultPodSpec(t *testing.T) {
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 
 	expectedServiceAccount := "sonobuoy-serviceaccount"
 	if pod.Spec.ServiceAccountName != expectedServiceAccount {
@@ -243,7 +243,7 @@ func TestCreatePodDefinitionUsesProvidedPodSpec(t *testing.T) {
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 
 	if pod.Spec.ServiceAccountName != expectedServiceAccountName {
 		t.Errorf("expected pod spec to have provided service account name %q, got %q", expectedServiceAccountName, pod.Spec.ServiceAccountName)
@@ -280,7 +280,7 @@ func TestCreatePodDefinitionAddsToExistingResourcesInPodSpec(t *testing.T) {
 		t.Fatalf("couldn't create client certificate: %v", err)
 	}
 
-	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results")
+	pod := testPlugin.createPodDefinition("", clientCert, &corev1.Pod{}, "", "/tmp/sonobuoy/results", "done")
 
 	// Existing container in pod spec, plus 2 added by Sonobuoy
 	expectedNumContainers := 3
@@ -325,7 +325,7 @@ func TestCreatePodDefinitionSetsOwnerReference(t *testing.T) {
 		},
 	}
 
-	pod := testPlugin.createPodDefinition("", clientCert, &aggregatorPod, "", "/tmp/sonobuoy/results")
+	pod := testPlugin.createPodDefinition("", clientCert, &aggregatorPod, "", "/tmp/sonobuoy/results", "done")
 	ownerReferences := pod.ObjectMeta.OwnerReferences
 
 	if len(ownerReferences) != 1 {

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -39,7 +39,7 @@ const (
 type Interface interface {
 	// Run runs a plugin, declaring all resources it needs, and then
 	// returns.  It does not block and wait until the plugin has finished.
-	Run(kubeClient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir string) error
+	Run(kubeClient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir, doneFile string) error
 
 	// Cleanup cleans up all resources created by the plugin
 	Cleanup(kubeClient kubernetes.Interface)

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -139,6 +139,27 @@ func TestRunGlobalCleanup(t *testing.T) {
 	})
 }
 
+func TestRunCustomDoneFile(t *testing.T) {
+	expectedResults := []plugin.ExpectedResult{
+		{ResultType: "systemd_logs"},
+	}
+	stopc := make(chan struct{}, 1)
+	stopc <- struct{}{}
+	withAggregator(t, expectedResults, func(aggr *aggregation.Aggregator, srv *authtest.Server) {
+		url, err := aggregation.GlobalResultURL(srv.URL, "systemd_logs")
+		if err != nil {
+			t.Fatalf("unexpected error getting global result url %v", err)
+		}
+
+		withTempDir(t, func(tmpdir string) {
+			err := GatherResults(filepath.Join(tmpdir, "customDone"), url, srv.Client(), stopc)
+			if err != nil {
+				t.Fatalf("Got error running agent: %v", err)
+			}
+		})
+	})
+}
+
 func TestRelayProgress(t *testing.T) {
 	tcs := []struct {
 		desc           string


### PR DESCRIPTION
Allow the user to specify a custom 'done' file. This enables
the plugin to write to a file which a post-processor can intercept
before the worker grabs it and send it to the aggregator.

Fixes #1530

Signed-off-by: John Schnake <jschnake@vmware.com>

```
Adds a new config option to allow the specification of the `done` file which the sonobuoy worker and plugin will use to coordinate activity.
```