### PR TITLE
Fix template for namespaced permissions

### DIFF
--- a/pkg/client/gen.tmpl.yaml
+++ b/pkg/client/gen.tmpl.yaml
@@ -1,9 +1,11 @@
 ---
+{{- if .ClusterAdmin }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Namespace}}
 ---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -22,11 +24,17 @@ kind: RoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: {{.Namespace}}
   name: sonobuoy-serviceaccount-{{.Namespace}}
+{{- if not .ClusterAdmin }}
+  namespace: {{.Namespace}}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .ClusterAdmin }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: sonobuoy-serviceaccount-{{.Namespace}}
 subjects:
 - kind: ServiceAccount
@@ -34,12 +42,18 @@ subjects:
   namespace: {{.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .ClusterAdmin }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   labels:
     component: sonobuoy
-    namespace: {{.Namespace}}
   name: sonobuoy-serviceaccount-{{.Namespace}}
+{{- if not .ClusterAdmin }}
+  namespace: {{.Namespace}}
+{{- end }}
 rules:
 - apiGroups:
   - '*'
@@ -47,12 +61,14 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- if .ClusterAdmin }}
 - nonResourceURLs:
   - '/metrics'
   - '/logs'
   - '/logs/*'
   verbs:
   - 'get'
+{{- end }}
 {{- end }}
 {{- if .SSHKey }}
 ---

--- a/pkg/client/testdata/aggregatorpermissions-noncluster-admin.golden
+++ b/pkg/client/testdata/aggregatorpermissions-noncluster-admin.golden
@@ -1,10 +1,5 @@
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: sonobuoy
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:

--- a/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
@@ -1,10 +1,5 @@
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: sonobuoy
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
@@ -17,11 +12,11 @@ kind: RoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
+  namespace: sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: sonobuoy-serviceaccount-sonobuoy
 subjects:
 - kind: ServiceAccount
@@ -29,12 +24,12 @@ subjects:
   namespace: sonobuoy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
+  namespace: sonobuoy
 rules:
 - apiGroups:
   - '*'
@@ -42,12 +37,6 @@ rules:
   - '*'
   verbs:
   - '*'
-- nonResourceURLs:
-  - '/metrics'
-  - '/logs'
-  - '/logs/*'
-  verbs:
-  - 'get'
 ---
 apiVersion: v1
 data:

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: configfileNS
   name: sonobuoy-serviceaccount-configfileNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: configfileNS
   name: sonobuoy-serviceaccount-configfileNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -18,7 +18,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34,7 +33,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1528.golden
+++ b/test/integration/testdata/gen-issue-1528.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-mode-and-focus.golden
+++ b/test/integration/testdata/gen-mode-and-focus.golden
@@ -18,7 +18,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34,7 +33,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-mode-and-rerun.golden
+++ b/test/integration/testdata/gen-mode-and-rerun.golden
@@ -18,7 +18,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34,7 +33,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-plugin-renaming.golden
+++ b/test/integration/testdata/gen-plugin-renaming.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-security-context-none.golden
+++ b/test/integration/testdata/gen-security-context-none.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/plugin-loading-installed.golden
+++ b/test/integration/testdata/plugin-loading-installed.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/plugin-loading-local.golden
+++ b/test/integration/testdata/plugin-loading-local.golden
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +32,6 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
-    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:


### PR DESCRIPTION
- do not create namespace
- namespace should be in metadata, not metadata.label
- in clusterAdmin mode, no need for namespace in metadata.label
- do not use non-resource URLs for namespaced role as they are not allowed

I think the template is too hard to read at this point and we should
translate it into code so it is easier to read, modify, and debug.

There are other issues with the run code itself that will cause the namespaced
permissions to fail, but this is the first step.

Signed-off-by: John Schnake <jschnake@vmware.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
