### PR TITLE
Modify entrypoint for getting e2e test images

### DIFF
--- a/pkg/image/docker/client.go
+++ b/pkg/image/docker/client.go
@@ -17,6 +17,8 @@ limitations under the License.
 package docker
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/sonobuoy/pkg/image/exec"
 )
@@ -28,14 +30,18 @@ type Docker interface {
 	Tag(src, dest string, retries int) error
 	Rmi(image string, retries int) error
 	Save(images []string, filename string) error
-	Run(image string, args ...string) ([]string, error)
+	Run(image string, entryPoint string, args ...string) ([]string, error)
 }
 
 type LocalDocker struct {
 }
 
-func (l LocalDocker) Run(image string, args ...string) ([]string, error) {
-	dockerArgs := []string{"run", "--rm", image}
+func (l LocalDocker) Run(image string, entryPoint string, args ...string) ([]string, error) {
+	dockerArgs := []string{"run", "--rm"}
+	if len(entryPoint) > 0 {
+		dockerArgs = append(dockerArgs, fmt.Sprintf("--entrypoint=%v", entryPoint))
+	}
+	dockerArgs = append(dockerArgs, image)
 	dockerArgs = append(dockerArgs, args...)
 	cmd := exec.Command("docker", dockerArgs...)
 	return exec.CombinedOutputLines(cmd)

--- a/pkg/image/docker_client.go
+++ b/pkg/image/docker_client.go
@@ -109,8 +109,8 @@ func (i DockerClient) DeleteImages(images []string, retries int) []error {
 	return errs
 }
 
-func (i DockerClient) RunImage(image string, args ...string) ([]string, error) {
-	output, err := i.dockerClient.Run(image, args...)
+func (i DockerClient) RunImage(image string, entryPoint string, args ...string) ([]string, error) {
+	output, err := i.dockerClient.Run(image, entryPoint, args...)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/image/docker_client_test.go
+++ b/pkg/image/docker_client_test.go
@@ -34,8 +34,8 @@ type FakeDockerClient struct {
 	deleteFails bool
 }
 
-func (l FakeDockerClient) Run(image string, args ...string) ([]string, error) {
-	return l.Run(image, args...)
+func (l FakeDockerClient) Run(image string, entryPoint string, args ...string) ([]string, error) {
+	return l.Run(image, entryPoint, args...)
 }
 
 func (l FakeDockerClient) PullIfNotPresent(image string, retries int) error {

--- a/pkg/image/dryrun_client.go
+++ b/pkg/image/dryrun_client.go
@@ -17,8 +17,9 @@ limitations under the License.
 package image
 
 import (
-	"github.com/sirupsen/logrus"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // DryRunClient is an implementation of Client that logs the image operations that would
@@ -65,7 +66,7 @@ gcr.io/kubernetes-e2e-test-images/kitten:1.0
 k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2
 `
 
-func (i DryRunClient) RunImage(image string, args ...string) ([]string, error) {
+func (i DryRunClient) RunImage(image string, entryPoint string, args ...string) ([]string, error) {
 	return strings.Split(v1_19_images, "\n"), nil
 }
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -22,5 +22,5 @@ type Client interface {
 	PushImages(images []TagPair, retries int) []error
 	DownloadImages(images []string, version string) (string, error)
 	DeleteImages(images []string, retries int) []error
-	RunImage(image string, args ...string) ([]string, error)
+	RunImage(image string, entrypoint string, args ...string) ([]string, error)
 }


### PR DESCRIPTION
The entrypoint for the conformance image changed in
v1.22 which means that the way that we were invoking
the image with `--list-images` was not working correctly.
Instead, it would ignore that flag and still try and run
the kubeconformance (gorunner) which would start the tests.

Signed-off-by: John Schnake <jschnake@vmware.com>


**Which issue(s) this PR fixes**
- Fixes #1546

**Release note**:
```
Fixed a bug which caused `sonobuoy images` to fail for Kubernetes v1.22+
```
