### PR TITLE
Roles and bindings should have namespace label for deltion

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -431,7 +431,7 @@ func generateRBAC(w io.Writer, cfg *GenConfig) error {
 		crb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"})
 
 		crb.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
-		crb.Labels = map[string]string{"component": "sonobuoy"}
+		crb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
 		crb.RoleRef = v1.RoleRef{
 			Name:     fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace),
 			Kind:     "ClusterRole",
@@ -445,7 +445,7 @@ func generateRBAC(w io.Writer, cfg *GenConfig) error {
 			},
 		}
 		cr.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
-		cr.Labels = map[string]string{"component": "sonobuoy"}
+		cr.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
 		cr.Rules = []v1.PolicyRule{
 			{
 				APIGroups: []string{"*"},
@@ -467,7 +467,7 @@ func generateRBAC(w io.Writer, cfg *GenConfig) error {
 		rb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
 		rb.Name = "sonobuoy-serviceaccount-sonobuoy"
 		rb.Namespace = cfg.Config.Namespace
-		rb.Labels = map[string]string{"component": "sonobuoy"}
+		rb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
 		rb.RoleRef = v1.RoleRef{
 			Name:     "sonobuoy-serviceaccount-sonobuoy",
 			Kind:     "Role",
@@ -482,7 +482,7 @@ func generateRBAC(w io.Writer, cfg *GenConfig) error {
 		}
 		r.Name = "sonobuoy-serviceaccount-sonobuoy"
 		r.Namespace = cfg.Config.Namespace
-		r.Labels = map[string]string{"component": "sonobuoy"}
+		r.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
 		r.Rules = []v1.PolicyRule{
 			{
 				APIGroups: []string{"*"},

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -52,6 +52,10 @@ stress() {
 }
 
 integration() {
+  # Download linux kubectl and move into default path for tests
+  curl --output ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
+  chmod +x ./kubectl
+
     docker run --rm \
         -v "$(pwd)":$BUILDMNT \
         -v /tmp/artifacts:/tmp/artifacts \
@@ -60,9 +64,20 @@ integration() {
         -w "$BUILDMNT" \
         --env ARTIFACTS_DIR=/tmp/artifacts \
         --env SONOBUOY_CLI="$SONOBUOY_CLI" \
+        --env KUBECTL_CLI="$KUBECTL_CLI" \
         --network host \
         "$BUILD_IMAGE" \
     go test ${VERBOSE:+-v} -tags=integration "$GOTARGET"/test/integration/...
+}
+
+local_integration(){
+  # Build linx binary and move into default path for tests
+  build_binary_GOOS_GOARCH linux amd64
+  cp ./build/linux/amd64/sonobuoy ./sonobuoy
+  # Download linux kubectl and move into default path for tests
+  curl --output ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
+  chmod +x ./kubectl
+  integration
 }
 
 lint() {

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -29,3 +29,4 @@ WORKDIR /
 COPY --from=base /go/bin/testImage /testImage
 COPY resources /resources
 CMD [ "/testImage" ]
+

--- a/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
@@ -11,6 +11,7 @@ kind: RoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
   namespace: sonobuoy
 roleRef:
@@ -27,6 +28,7 @@ kind: Role
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
   namespace: sonobuoy
 rules:

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: configfileNS
   name: sonobuoy-serviceaccount-configfileNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: configfileNS
   name: sonobuoy-serviceaccount-configfileNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -17,6 +17,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,6 +33,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-issue-1528.golden
+++ b/test/integration/testdata/gen-issue-1528.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-mode-and-focus.golden
+++ b/test/integration/testdata/gen-mode-and-focus.golden
@@ -17,6 +17,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,6 +33,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-mode-and-rerun.golden
+++ b/test/integration/testdata/gen-mode-and-rerun.golden
@@ -17,6 +17,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,6 +33,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-plugin-renaming.golden
+++ b/test/integration/testdata/gen-plugin-renaming.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-security-context-none.golden
+++ b/test/integration/testdata/gen-security-context-none.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: cmdlineNS
   name: sonobuoy-serviceaccount-cmdlineNS
 rules:
 - apiGroups:

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/plugin-loading-installed.golden
+++ b/test/integration/testdata/plugin-loading-installed.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:

--- a/test/integration/testdata/plugin-loading-local.golden
+++ b/test/integration/testdata/plugin-loading-local.golden
@@ -16,6 +16,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +32,7 @@ kind: ClusterRole
 metadata:
   labels:
     component: sonobuoy
+    namespace: sonobuoy
   name: sonobuoy-serviceaccount-sonobuoy
 rules:
 - apiGroups:


### PR DESCRIPTION
- label for namespace was expected, not to place it into that
namespace but to identify it as being related to that namespace's run.
- if DeleteAll is set, delete all regardless of namespace

Signed-off-by: John Schnake <jschnake@vmware.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #1548 

**Release note**:
```
Fixed a bug which caused cluster roles and bindings to not be deleted.
Modified the behavior of `sonobuoy delete --all` to include deleting all cluster roles related to any Sonobuoy run, regardless of namespace.
Added back a "namespace" label for ClusterRoles and ClusterRoleBindings in order to properly associate them with their Sonobuoy run.
```
