### PR TITLE
Add docs for result type gojson

### DIFF
--- a/site/content/docs/main/plugins.md
+++ b/site/content/docs/main/plugins.md
@@ -84,9 +84,11 @@ to present results metadata to the end user such as the number of passed/failed 
 the number of files gathered.
 
 This inspection process is informed by the YAML that described the plugin defintion. The
-`result-type` field can be set to either `raw`, `junit`, or `manual`.
+`result-type` field can be set to either `raw`, `junit`, `gojson`, or `manual`.
 
 When set to `junit`, Sonobuoy will look for XML files and process them as junit test results.
+
+When set to `gojson`, Sonobuoy will look for JSON files and process them as JSON output from `go test` [See details here.](https://golang.org/cmd/test2json/)
 
 When set to `raw`, Sonobuoy will simply inspect all the files and record the number of files generated.
 

--- a/site/content/docs/main/results.md
+++ b/site/content/docs/main/results.md
@@ -159,8 +159,9 @@ For `DaemonSet` plugins, where results files will be generated for each node, th
 ## Summary
 
  - `sonobuoy results` can show you results of a plugin without extracting the tarball
-   - Plugins are either `junit`, `raw` or `manual` type currently
+   - Plugins are either `junit`, `gojson`, `raw` or `manual` type currently
    - When viewing `junit` results, json data is dumped for each test
+   - When viewing `gojson` results, json data is dumped for each test
    - When viewing `raw` results, file contents are dumped directly
    - When viewing `manual` results, results are included as provided by the plugin
  - Use the `--mode` flag to see either report, detail, or dump level data


### PR DESCRIPTION
This was added a few releases ago but never documented.
Just adding it into main and the next release docs will
start showing them.

Fixes #1555 

Signed-off-by: John Schnake <jschnake@vmware.com>