### PR TITLE
Continue with run even if unable to query nodes

### DIFF
--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -132,7 +132,7 @@ func cleanupNamespace(namespace string, client kubernetes.Interface) (ConditionF
 			return fmt.Sprintf("Namespace %q has been deleted", namespace), true, nil
 		}
 		if err != nil {
-			status := fmt.Sprintf("Error encountered while trying to delete namespace %q: %v", ns.Name, err)
+			status := fmt.Sprintf("Error encountered while waiting for namespace deletion %q: %v", ns.Name, err)
 			return status, false, err
 		}
 		if ns != nil {


### PR DESCRIPTION
Early in the run we gather nodes so that we know what results to expect
for the daemonsets. The new logic is:
 - log a warning that this failed and indicate the daemonsets will not work
 - since we dont have node names we dont know what results to expect/wait for
for daemonsets, so we just dont expect or wait for daemonsets at all
 - when doing pod log queries, even though we cant query for all namespaces,
we know our current namespace and can query that if specified
 - when doing resource queries, we likewise query those for the current
namespace

I think this should resolve the two issues below:

Fixes #1542 
Fixes #1470 

I am able to get runs started and even get some extra debug info like podlogs (for the test namespace) and API info for objects in that namespace too.