### PR TITLE
Add namespaced permissions with cluster read

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -421,79 +421,164 @@ func generateConfigMap(w io.Writer, cfg *GenConfig) error {
 	return appendAsYAML(w, cm)
 }
 
+func clusterAdminRBAC(w io.Writer, cfg *GenConfig) error {
+	cr, crb := &v1.ClusterRole{}, &v1.ClusterRoleBinding{}
+	cr.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
+	crb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"})
+
+	crb.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
+	crb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	crb.RoleRef = v1.RoleRef{
+		Name:     fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace),
+		Kind:     "ClusterRole",
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+	crb.Subjects = []v1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "sonobuoy-serviceaccount",
+			Namespace: cfg.Config.Namespace,
+		},
+	}
+	cr.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
+	cr.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	cr.Rules = []v1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+		{
+			NonResourceURLs: []string{"/metrics", "/logs", "/logs/*"},
+			Verbs:           []string{"get"},
+		},
+	}
+	if err := appendAsYAML(w, crb); err != nil {
+		return err
+	}
+	return appendAsYAML(w, cr)
+}
+
+func clusterReadRBAC(w io.Writer, cfg *GenConfig) error {
+	cr, crb := &v1.ClusterRole{}, &v1.ClusterRoleBinding{}
+	cr.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
+	crb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"})
+
+	crb.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
+	crb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	crb.RoleRef = v1.RoleRef{
+		Name:     fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace),
+		Kind:     "ClusterRole",
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+	crb.Subjects = []v1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "sonobuoy-serviceaccount",
+			Namespace: cfg.Config.Namespace,
+		},
+	}
+	cr.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
+	cr.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	cr.Rules = []v1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			NonResourceURLs: []string{"/metrics", "/logs", "/logs/*"},
+			Verbs:           []string{"get"},
+		},
+	}
+	if err := appendAsYAML(w, crb); err != nil {
+		return err
+	}
+	if err := appendAsYAML(w, cr); err != nil {
+		return err
+	}
+	r, rb := &v1.Role{}, &v1.RoleBinding{}
+	r.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"})
+	rb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+	rb.Name = "sonobuoy-serviceaccount-sonobuoy"
+	rb.Namespace = cfg.Config.Namespace
+	rb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	rb.RoleRef = v1.RoleRef{
+		Name:     "sonobuoy-serviceaccount-sonobuoy",
+		Kind:     "Role",
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+	rb.Subjects = []v1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "sonobuoy-serviceaccount",
+			Namespace: cfg.Config.Namespace,
+		},
+	}
+	r.Name = "sonobuoy-serviceaccount-sonobuoy"
+	r.Namespace = cfg.Config.Namespace
+	r.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	r.Rules = []v1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+	}
+	if err := appendAsYAML(w, rb); err != nil {
+		return err
+	}
+	return appendAsYAML(w, r)
+}
+func namespaceAdminRBAC(w io.Writer, cfg *GenConfig) error {
+	r, rb := &v1.Role{}, &v1.RoleBinding{}
+	r.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"})
+	rb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+	rb.Name = "sonobuoy-serviceaccount-sonobuoy"
+	rb.Namespace = cfg.Config.Namespace
+	rb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	rb.RoleRef = v1.RoleRef{
+		Name:     "sonobuoy-serviceaccount-sonobuoy",
+		Kind:     "Role",
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+	rb.Subjects = []v1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "sonobuoy-serviceaccount",
+			Namespace: cfg.Config.Namespace,
+		},
+	}
+	r.Name = "sonobuoy-serviceaccount-sonobuoy"
+	r.Namespace = cfg.Config.Namespace
+	r.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
+	r.Rules = []v1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+	}
+	if err := appendAsYAML(w, rb); err != nil {
+		return err
+	}
+	return appendAsYAML(w, r)
+}
+
 func generateRBAC(w io.Writer, cfg *GenConfig) error {
 	if !cfg.EnableRBAC {
 		return nil
 	}
-	if cfg.Config.AggregatorPermissions == config.AggregatorPermissionsClusterAdmin {
-		cr, crb := &v1.ClusterRole{}, &v1.ClusterRoleBinding{}
-		cr.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
-		crb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"})
 
-		crb.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
-		crb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
-		crb.RoleRef = v1.RoleRef{
-			Name:     fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace),
-			Kind:     "ClusterRole",
-			APIGroup: "rbac.authorization.k8s.io",
-		}
-		crb.Subjects = []v1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      "sonobuoy-serviceaccount",
-				Namespace: cfg.Config.Namespace,
-			},
-		}
-		cr.Name = fmt.Sprintf("sonobuoy-serviceaccount-%v", cfg.Config.Namespace)
-		cr.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
-		cr.Rules = []v1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-			{
-				NonResourceURLs: []string{"/metrics", "/logs", "/logs/*"},
-				Verbs:           []string{"get"},
-			},
-		}
-		if err := appendAsYAML(w, crb); err != nil {
-			return err
-		}
-		return appendAsYAML(w, cr)
-	} else {
-		r, rb := &v1.Role{}, &v1.RoleBinding{}
-		r.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"})
-		rb.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
-		rb.Name = "sonobuoy-serviceaccount-sonobuoy"
-		rb.Namespace = cfg.Config.Namespace
-		rb.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
-		rb.RoleRef = v1.RoleRef{
-			Name:     "sonobuoy-serviceaccount-sonobuoy",
-			Kind:     "Role",
-			APIGroup: "rbac.authorization.k8s.io",
-		}
-		rb.Subjects = []v1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      "sonobuoy-serviceaccount",
-				Namespace: cfg.Config.Namespace,
-			},
-		}
-		r.Name = "sonobuoy-serviceaccount-sonobuoy"
-		r.Namespace = cfg.Config.Namespace
-		r.Labels = map[string]string{clusterRoleFieldName: clusterRoleFieldValue, clusterRoleFieldNamespace: cfg.Config.Namespace}
-		r.Rules = []v1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		}
-		if err := appendAsYAML(w, rb); err != nil {
-			return err
-		}
-		return appendAsYAML(w, r)
+	switch cfg.Config.AggregatorPermissions {
+	case config.AggregatorPermissionsClusterAdmin:
+		return clusterAdminRBAC(w, cfg)
+	case config.AggregatorPermissionsNamespaceAdmin:
+		return namespaceAdminRBAC(w, cfg)
+	case config.AggregatorPermissionsClusterRead:
+		return clusterReadRBAC(w, cfg)
+	default:
+		return fmt.Errorf("unknown aggregator permission: %v", cfg.Config.AggregatorPermissions)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,8 +65,10 @@ const (
 	// runAsUser, runAsGroup, and fsGroup. 'none' skips setting those it entirely since Windows does not support them.
 	DefaultSecurityContextMode = "nonroot"
 
-	AggregatorPermissionsClusterAdmin = "clusterAdmin"
-	DefaultAggregatorPermissions      = AggregatorPermissionsClusterAdmin
+	AggregatorPermissionsClusterAdmin   = "clusterAdmin"
+	AggregatorPermissionsClusterRead    = "clusterRead"
+	AggregatorPermissionsNamespaceAdmin = "namespaceAdmin"
+	DefaultAggregatorPermissions        = AggregatorPermissionsClusterAdmin
 )
 
 var (

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -694,9 +694,17 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			cmdLine:    "gen --security-context-mode=none --kubernetes-version=ignore",
 			expectFile: "testdata/gen-security-context-none.golden",
 		}, {
-			desc:       "gen with aggregator permissions namespaced",
-			cmdLine:    "gen --aggregator-permissions=namespaced --kubernetes-version=ignore",
+			desc:       "gen with aggregator permissions namespaceAdmin",
+			cmdLine:    "gen --aggregator-permissions=namespaceAdmin --kubernetes-version=ignore",
 			expectFile: "testdata/gen-aggregator-permissions-namespaced.golden",
+		}, {
+			desc:       "gen with aggregator permissions clusterRead",
+			cmdLine:    "gen --aggregator-permissions=clusterRead --kubernetes-version=ignore",
+			expectFile: "testdata/gen-aggregator-permissions-clusterRead.golden",
+		}, {
+			desc:       "gen with aggregator permissions invalid",
+			cmdLine:    "gen --aggregator-permissions=invalid --kubernetes-version=ignore",
+			expectFile: "testdata/gen-aggregator-permissions-invalid.golden",
 		}, {
 			desc:       "allow plugin renaming",
 			cmdLine:    "gen -p testdata/hello-world.yaml@goodbye -p testImage/yaml/job-junit-passing-singlefile.yaml@customname --kubernetes-version=ignore",

--- a/test/integration/testdata/gen-aggregator-permissions-clusterRead.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-clusterRead.golden
@@ -7,6 +7,45 @@ metadata:
   namespace: sonobuoy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount-sonobuoy
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  - /logs
+  - /logs/*
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -41,7 +80,7 @@ rules:
 ---
 apiVersion: v1
 data:
-  config.json: '{"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","AggregatorPermissions":"namespaceAdmin","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}'
+  config.json: '{"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","AggregatorPermissions":"clusterRead","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}'
 kind: ConfigMap
 metadata:
   labels:

--- a/test/integration/testdata/gen-aggregator-permissions-invalid.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-invalid.golden
@@ -1,0 +1,1 @@
+time="STATIC_TIME_FOR_TESTING" level=error msg="error attempting to generate sonobuoy manifest: failed to generate YAML from configuration: unknown aggregator permission: invalid"


### PR DESCRIPTION
Makes sense if we are going to allow customization of
aggregator permissions that we provide a few useful options.

In the originating ticket, the users wanted a strictly namespaced
permissions set.

It also makes sense, to offer a namespaced permission set that comes
with cluster reads. This allows us to run daemonsets (requires listing
nodes) and allows plugins to check things like kube-system pods.

In this permission mode, e2e tests will start (checks nodes are up
and kube-system pods are ready) but will fail since tests require that
namespaces get created (which it lacks permissions for).

Signed-off-by: John Schnake <jschnake@vmware.com>

```
Adds a `clusterRead` aggregator permission set which is effectively namespace admin plus cluster-wide read/list/watch. This allows cluster queries for debugging and daemonsets to work properly (which requires listing nodes in order to know which/how many results to expect).
```