### PR TITLE
Add sonobuoy modes command

### DIFF
--- a/cmd/sonobuoy/app/modes.go
+++ b/cmd/sonobuoy/app/modes.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 Sonobuoy Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+type e2eModeOptions struct {
+	name        string
+	desc        string
+	focus, skip string
+	parallel    bool
+}
+
+const (
+	// E2eModeQuick runs a single E2E test and the systemd log tests.
+	E2eModeQuick string = "quick"
+
+	// E2eModeNonDisruptiveConformance runs all of the `Conformance` E2E tests which are not marked as disuprtive and the systemd log tests.
+	E2eModeNonDisruptiveConformance string = "non-disruptive-conformance"
+
+	// E2eModeCertifiedConformance runs all of the `Conformance` E2E tests and the systemd log tests.
+	E2eModeCertifiedConformance string = "certified-conformance"
+
+	// nonDisruptiveSkipList should generally just need to skip disruptive tests since upstream
+	// will disallow the other types of tests from being tagged as Conformance. However, in v1.16
+	// two disruptive tests were  not marked as such, meaning we needed to specify them here to ensure
+	// user workload safety. See https://github.com/kubernetes/kubernetes/issues/82663
+	// and https://github.com/kubernetes/kubernetes/issues/82787
+	nonDisruptiveSkipList = `\[Disruptive\]|NoExecuteTaintManager`
+	conformanceFocus      = `\[Conformance\]`
+	quickFocus            = "Pods should be submitted and removed"
+)
+
+// validModes is a map of the various valid modes. Name is duplicated as the key and in the e2eModeOptions itself.
+var validModes = map[string]e2eModeOptions{
+	E2eModeQuick: {
+		name: E2eModeQuick, focus: quickFocus,
+		desc: "Quick mode runs a single test to create and destroy a pod. Fastest way to check basic cluster operation.",
+	},
+	E2eModeNonDisruptiveConformance: {
+		name: E2eModeNonDisruptiveConformance, focus: conformanceFocus, skip: nonDisruptiveSkipList,
+		desc: "Non-destructive conformance mode runs all of the conformance tests except those that would disrupt other cluster operations (e.g. tests that may cause nodes to be restarted or impact cluster permissions).",
+	},
+	E2eModeCertifiedConformance: {
+		name: E2eModeCertifiedConformance, focus: conformanceFocus,
+		desc: "Certified conformance mode runs the entire conformance suite, even disruptive tests. This is typically run in a dev environment to earn the CNCF Certified Kubernetes status.",
+	},
+}
+
+func validE2eModes() []string {
+	keys := []string{}
+	for key := range validModes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func NewCmdModes() *cobra.Command {
+	var modesCmd = &cobra.Command{
+		Use:   "modes",
+		Short: "Display the various modes in which to run the e2e plugin",
+		Run:   showModes(),
+		Args:  cobra.ExactArgs(0),
+	}
+	return modesCmd
+}
+
+func showModes() func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		for i, key := range validE2eModes() {
+			opt := validModes[key]
+			if i != 0 {
+				fmt.Println("")
+			}
+			fmt.Printf("Mode: %v\n", opt.name)
+			fmt.Printf("Description: %v\n", opt.desc)
+			fmt.Printf("E2E_FOCUS: %v\n", opt.focus)
+			fmt.Printf("E2E_SKIP: %v\n", opt.skip)
+			fmt.Printf("E2E_PARALLEL: %v\n", opt.parallel)
+		}
+	}
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -64,6 +64,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdWait())
 
 	cmds.AddCommand(NewCmdQuery())
+	cmds.AddCommand(NewCmdModes())
 
 	cmds.AddCommand(NewCmdPlugin())
 

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -725,6 +725,10 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			desc:       "Support for KUBE_TEST_REPO in e2e plugin",
 			cmdLine:    "gen -p e2e --e2e-repo foo --kubernetes-version=ignore",
 			expectFile: "testdata/gen-kube-test-repo.golden",
+		}, {
+			desc:       "sonobuoy modes command",
+			cmdLine:    "modes",
+			expectFile: "testdata/modes.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [non-disruptive-conformance certified-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [non-disruptive-conformance certified-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [non-disruptive-conformance certified-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/modes.golden
+++ b/test/integration/testdata/modes.golden
@@ -1,0 +1,17 @@
+Mode: certified-conformance
+Description: Certified conformance mode runs the entire conformance suite, even disruptive tests. This is typically run in a dev environment to earn the CNCF Certified Kubernetes status.
+E2E_FOCUS: \[Conformance\]
+E2E_SKIP: 
+E2E_PARALLEL: false
+
+Mode: non-disruptive-conformance
+Description: Non-destructive conformance mode runs all of the conformance tests except those that would disrupt other cluster operations (e.g. tests that may cause nodes to be restarted or impact cluster permissions).
+E2E_FOCUS: \[Conformance\]
+E2E_SKIP: \[Disruptive\]|NoExecuteTaintManager
+E2E_PARALLEL: false
+
+Mode: quick
+Description: Quick mode runs a single test to create and destroy a pod. Fastest way to check basic cluster operation.
+E2E_FOCUS: Pods should be submitted and removed
+E2E_SKIP: 
+E2E_PARALLEL: false


### PR DESCRIPTION
Add a way to list what modes are supported, their focus/skip/parallel
values, and their descriptions.

This expands the ability for Sonobuoy to self-document and allows us
to expand which modes are available so that different test sets can be
run.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1570

**Release note**:
```
Added a new `sonobuoy modes` command which list available modes for the e2e plugin.
```
