### PR TITLE
Support KUBE_TEST_REPO

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -47,6 +47,7 @@ const (
 	e2eSkipFlag               = "e2e-skip"
 	e2eParallelFlag           = "e2e-parallel"
 	e2eRegistryConfigFlag     = "e2e-repo-config"
+	e2eRegistryFlag           = "e2e-repo"
 	pluginImageFlag           = "plugin-image"
 	filenameFlag              = "filename"
 	retrievePathFlag          = "retrieve-path"
@@ -189,7 +190,15 @@ func AddAggregatorPermissionsFlag(mode *string, flags *pflag.FlagSet) {
 func AddE2ERegistryConfigFlag(cfg *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		cfg, e2eRegistryConfigFlag, "",
-		"Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images. Required when pushing images for the e2e plugin.",
+		"Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.",
+	)
+}
+
+// AddE2ERegistryFlag adds a e2eRegistryFlag flag to the provided command.
+func AddE2ERegistryFlag(cfg *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		cfg, e2eRegistryFlag, "",
+		"Specify a registry for KUBE_TEST_REPO, overriding registries for test images.",
 	)
 }
 
@@ -271,6 +280,11 @@ func AddLegacyE2EFlags(env *PluginEnvVars, pluginTransforms *map[string][]func(*
 			transforms: *pluginTransforms,
 		}, e2eRegistryConfigFlag,
 		"Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.",
+	)
+
+	fs.Var(
+		&envVarModierFlag{plugin: e2ePlugin, field: "KUBE_TEST_REPO", PluginEnvVars: *env}, e2eRegistryFlag,
+		"Specify a registry to use as the default for pulling Kubernetes test images. Same as providing --e2e-repo-config but specifying the same repo repeatedly.",
 	)
 }
 

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -119,6 +119,11 @@ func prerunChecks(cmd *cobra.Command, args []string) error {
 	if flagsSet["kube-conformance-image"] && (flagsSet["kubernetes-version"] || flagsSet["kube-conformance-image-version"]) {
 		logrus.Warnf("kube-conformance-image flag and kubernetes-version/kube-conformance-image-version flags both set and may collide")
 	}
+
+	if flagsSet[e2eRegistryConfigFlag] && flagsSet[e2eRegistryFlag] {
+		logrus.Warnf("%v and %v flags are both set and may collide", e2eRegistryConfigFlag, e2eRegistryFlag)
+	}
+
 	return nil
 }
 

--- a/site/content/docs/main/airgap.md
+++ b/site/content/docs/main/airgap.md
@@ -56,7 +56,9 @@ sonobuoy run --kube-conformance-image $PRIVATE_REG/conformance:$CLUSTER_VERSION
 The end-to-end tests use a number of different images across multiple registries.
 When running the `e2e` plugin, you must provide a mapping that details which custom registries should be used instead of the public registries.
 
-This mapping is a YAML file which maps the registry category to the corresponding registry URL.
+If you need only a single, custom registry, use the `--e2e-repo` flag to specify that all test registry should be set to the same, given value.
+
+If you need multiple registries, you must provide a mapping that the upstream Kubernetes tests understand. It is provided via a YAML file which maps the registry category to the corresponding registry URL.
 The keys in this file are specified in the Kubernetes test framework.
 The tests for each minor version of Kubernetes use a different set of registries so the mapping you create will depend on which Kubernetes version you are testing against.
 
@@ -87,17 +89,22 @@ sonobuoy images pull
 > You may see these errors when running the above command. This is expected behaviour.
 > These images are referenced by some end-to-end tests, but **not** by the conformance tests.
 
-To push the images, you must provide the mapping using the `--e2e-repo-config` flag as follows: 
+To push the images, you must provide the mapping using the `--e2e-repo` or `--e2e-repo-config` flag as follows: 
 
 ```
+sonobuoy images push --e2e-repo <your registry>
+// OR
 sonobuoy images push --e2e-repo-config <path/to/custom-repo-config.yaml>
 ```
 
-Sonobuoy will read the mapping config and will push the images to the repositories defined in that mapping.
+If you are pushing to a single registry; use the first flag; if you need fine-grained controle
+over which images go to which registry, use the second.
 
-When running the `e2e` plugin, you will need to provide this file using the same flag as follows:
+When running the `e2e` plugin, you will need to provide this information using the same flag as follows:
 
 ```
+sonobuoy run --e2e-repo <your registry>
+// OR
 sonobuoy run --e2e-repo-config <path/to/custom-repo-config.yaml>
 ```
 

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -713,6 +713,10 @@ func TestExactOutput_LocalGolden(t *testing.T) {
 			desc:       "multiple plugins and multiple containers issue 1528",
 			cmdLine:    "gen -p testdata/plugins/good/sidecar.yaml -p testdata/plugins/good/hello-world.yaml --kubernetes-version=ignore",
 			expectFile: "testdata/gen-issue-1528.golden",
+		}, {
+			desc:       "Support for KUBE_TEST_REPO in e2e plugin",
+			cmdLine:    "gen -p e2e --e2e-repo foo --kubernetes-version=ignore",
+			expectFile: "testdata/gen-kube-test-repo.golden",
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-kube-test-repo.golden
+++ b/test/integration/testdata/gen-kube-test-repo.golden
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount-sonobuoy
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+    namespace: sonobuoy
+  name: sonobuoy-serviceaccount-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - /metrics
+  - /logs
+  - /logs/*
+  verbs:
+  - get
+---
+apiVersion: v1
+data:
+  config.json: '{"Description":"DEFAULT","UUID":"","Version":"*STATIC_FOR_TESTING*","ResultsDir":"/tmp/sonobuoy/results","Resources":null,"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"kube-system","SonobuoyNamespace":true,"FieldSelectors":[],"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null}},"QPS":30,"Burst":50,"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":21600},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"sonobuoy","WorkerImage":"sonobuoy/sonobuoy:*STATIC_FOR_TESTING*","ImagePullPolicy":"IfNotPresent","ImagePullSecrets":"","AggregatorPermissions":"clusterAdmin","ProgressUpdatesPort":"8099","SecurityContextMode":"nonroot"}'
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |-
+    podSpec:
+      containers: []
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_EXTRA_ARGS
+        value: --progress-report-url=http://localhost:8099/progress
+      - name: E2E_FOCUS
+        value: \[Conformance\]
+      - name: E2E_PARALLEL
+        value: "false"
+      - name: E2E_SKIP
+        value: \[Disruptive\]|NoExecuteTaintManager
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
+      - name: KUBE_TEST_REPO
+        value: foo
+      - name: RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      - name: SONOBUOY
+        value: "true"
+      - name: SONOBUOY_CONFIG_DIR
+        value: /tmp/sonobuoy/config
+      - name: SONOBUOY_K8S_VERSION
+        value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
+      - name: SONOBUOY_RESULTS_DIR
+        value: /tmp/sonobuoy/results
+      image: k8s.gcr.io/conformance:ignore
+      imagePullPolicy: IfNotPresent
+      name: e2e
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  containers:
+  - args:
+    - aggregator
+    - --no-exit
+    - --level=info
+    - -v=4
+    - --alsologtostderr
+    command:
+    - /sonobuoy
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: sonobuoy/sonobuoy:*STATIC_FOR_TESTING*
+    imagePullPolicy: IfNotPresent
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  securityContext:
+    fsGroup: 2000
+    runAsGroup: 3000
+    runAsUser: 1000
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    sonobuoy-component: aggregator
+  name: sonobuoy-aggregator
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    sonobuoy-component: aggregator
+  type: ClusterIP
+---
+

--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -16,6 +16,7 @@ Flags:
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")
       --dns-pod-labels strings                   The label selectors to use for locating DNS pods during preflight checks. Can be specified multiple times or as a comma-separated list. (default [k8s-app=kube-dns,k8s-app=coredns])
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
+      --e2e-repo envModifier                     Specify a registry to use as the default for pulling Kubernetes test images. Same as providing --e2e-repo-config but specifying the same repo repeatedly.
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
   -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -16,6 +16,7 @@ Flags:
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")
       --dns-pod-labels strings                   The label selectors to use for locating DNS pods during preflight checks. Can be specified multiple times or as a comma-separated list. (default [k8s-app=kube-dns,k8s-app=coredns])
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
+      --e2e-repo envModifier                     Specify a registry to use as the default for pulling Kubernetes test images. Same as providing --e2e-repo-config but specifying the same repo repeatedly.
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
   -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -16,6 +16,7 @@ Flags:
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")
       --dns-pod-labels strings                   The label selectors to use for locating DNS pods during preflight checks. Can be specified multiple times or as a comma-separated list. (default [k8s-app=kube-dns,k8s-app=coredns])
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
+      --e2e-repo envModifier                     Specify a registry to use as the default for pulling Kubernetes test images. Same as providing --e2e-repo-config but specifying the same repo repeatedly.
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
   -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.


### PR DESCRIPTION
Upstream e2e tests added a shortcut for overriding the
test image repos; you can now set a single env var and
all test images will assume that repo. Adding the flag
here since that should be useful for many.

Signed-off-by: John Schnake <jschnake@vmware.com>


**Which issue(s) this PR fixes**
- Fixes #1557 

**Release note**:
```
Added a new --e2e-repo command which simplifies running in airgapped environments if you are using just a single registry.
```
