### PR TITLE
Add conformance-lite mode

### DIFF
--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance conformance-lite non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance conformance-lite non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -25,7 +25,7 @@ Flags:
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
       --kubeconfig Kubeconfig                    Path to explicit kubeconfig file.
       --kubernetes-version string                Use default E2E image, but override the version. Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise. 'ignore' will try version resolution but ignore errors. 'latest' will find the latest dev image/version upstream.
-  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance non-disruptive-conformance quick]. (default non-disruptive-conformance)
+  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance conformance-lite non-disruptive-conformance quick]. (default non-disruptive-conformance)
   -n, --namespace string                         The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously. (default "sonobuoy")
   -p, --plugin pluginList                        Which plugins to run. Can either point to a URL, local file/directory, or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.
       --plugin-env pluginenvvar                  Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value (default map[])

--- a/test/integration/testdata/modes.golden
+++ b/test/integration/testdata/modes.golden
@@ -4,8 +4,14 @@ E2E_FOCUS: \[Conformance\]
 E2E_SKIP: 
 E2E_PARALLEL: false
 
+Mode: conformance-lite
+Description: An unofficial mode of running the e2e tests which removes some of the longest running tests so that your tests can complete in the fastest time possible while maximizing coverage.
+E2E_FOCUS: \[Conformance\]
+E2E_SKIP: Serial|Slow|Disruptive|\[sig-apps\] StatefulSet Basic StatefulSet functionality \[StatefulSetBasic\] should have a working scale subresource \[Conformance\]|\[sig-network\] EndpointSlice sho... (truncated) ...
+E2E_PARALLEL: true
+
 Mode: non-disruptive-conformance
-Description: Non-destructive conformance mode runs all of the conformance tests except those that would disrupt other cluster operations (e.g. tests that may cause nodes to be restarted or impact cluster permissions).
+Description: Non-destructive conformance mode runs all of the conformance tests except those that would disrupt other cluster operations (e.g. tests that may cause nodes to be restarted or impact clus... (truncated) ...
 E2E_FOCUS: \[Conformance\]
 E2E_SKIP: \[Disruptive\]|NoExecuteTaintManager
 E2E_PARALLEL: false


### PR DESCRIPTION
The goal of this mode is to maximize coverage while minimizing
test time. I was able to get 257 tests in 334s.

This is just done from looking at old runs and sorting the tests
by time and avoiding running the slowest ones. We do not specify
the fastest ones because there are so many of them.

Signed-off-by: John Schnake <jschnake@vmware.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
