### PR TITLE
Worker sidecars get plugin env vars

### DIFF
--- a/pkg/k8s/env.go
+++ b/pkg/k8s/env.go
@@ -1,0 +1,51 @@
+/*
+Copyright the Sonobuoy contributors 2022
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// MergeEnv will combine the values from two env var sets with priority being
+// given to values in the first set in case of collision. Afterwards, any env
+// var with a name in the removal set will be removed.
+func MergeEnv(e1, e2 []corev1.EnvVar, removeKeys map[string]struct{}) []corev1.EnvVar {
+	envSet := map[string]corev1.EnvVar{}
+	returnEnv := []corev1.EnvVar{}
+	for _, e := range e1 {
+		envSet[e.Name] = e
+	}
+	for _, e := range e2 {
+		if _, seen := envSet[e.Name]; !seen {
+			envSet[e.Name] = e
+		}
+	}
+	for name, v := range envSet {
+		if _, remove := removeKeys[name]; !remove {
+			returnEnv = append(returnEnv, v)
+		}
+	}
+
+	sort.Slice(returnEnv, func(i, j int) bool {
+		return strings.ToLower(returnEnv[i].Name) < strings.ToLower(returnEnv[j].Name)
+	})
+
+	return returnEnv
+}

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	kutil "github.com/vmware-tanzu/sonobuoy/pkg/k8s"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/manifest"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,7 +241,7 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate, progres
 }
 
 // CreateWorkerContainerDefintion creates the container definition to run the Sonobuoy worker for a plugin.
-func (b *Base) CreateWorkerContainerDefintion(hostname string, cert *tls.Certificate, command, args []string, progressPort, resultDir string) v1.Container {
+func (b *Base) CreateWorkerContainerDefintion(hostname string, cert *tls.Certificate, command, args []string, progressPort, resultDir string, pluginEnv []v1.EnvVar) v1.Container {
 	container := v1.Container{
 		Name:            "sonobuoy-worker",
 		Image:           b.SonobuoyImage,
@@ -256,6 +257,8 @@ func (b *Base) CreateWorkerContainerDefintion(hostname string, cert *tls.Certifi
 			},
 		},
 	}
+	// Worker gets any env vars from main plugin.
+	container.Env = kutil.MergeEnv(container.Env, pluginEnv, nil)
 	return container
 }
 

--- a/pkg/plugin/driver/base_test.go
+++ b/pkg/plugin/driver/base_test.go
@@ -143,6 +143,7 @@ func TestCreateWorkerContainerDefinition(t *testing.T) {
 	cert := &tls.Certificate{Certificate: [][]byte{}}
 	command := []string{"sonobuoy"}
 	args := []string{"worker", "--global"}
+	presetPluginEnv := []v1.EnvVar{{Name: "FOO", Value: "BAR"}, {Name: "FOO2", Value: "BAR2"}}
 
 	b := &Base{
 		Definition: manifest.Manifest{
@@ -155,7 +156,7 @@ func TestCreateWorkerContainerDefinition(t *testing.T) {
 		SessionID:       "sessionID",
 	}
 
-	wc := b.CreateWorkerContainerDefintion(aggregatorURL, cert, command, args, "", "/tmp/sonobuoy/results")
+	wc := b.CreateWorkerContainerDefintion(aggregatorURL, cert, command, args, "", "/tmp/sonobuoy/results", presetPluginEnv)
 
 	checkFields := func(container v1.Container) error {
 		if container.Name != "sonobuoy-worker" {
@@ -181,6 +182,7 @@ func TestCreateWorkerContainerDefinition(t *testing.T) {
 				return fmt.Errorf("expected args item %v to be %q, got %q", i, args[i], arg)
 			}
 		}
+
 		return nil
 	}
 
@@ -203,6 +205,8 @@ func TestCreateWorkerContainerDefinition(t *testing.T) {
 				Value: "",
 			},
 		}
+		expectedEnvVars = append(expectedEnvVars, presetPluginEnv...)
+		
 		for _, e := range expectedEnvVars {
 			if !envContains(container.Env, e) {
 				return fmt.Errorf("expected container environment to contain %q", e)

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -195,7 +195,7 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy", "worker", "single-node", "--level=trace", "-v=6", "--logtostderr", "--sleep=" + defaultSleepSeconds}, []string{}, progressPort, resultDir),
+		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy", "worker", "single-node", "--level=trace", "-v=6", "--logtostderr", "--sleep=" + defaultSleepSeconds}, []string{}, progressPort, resultDir, p.Definition.Spec.Container.Env),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -116,7 +116,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "--level=trace", "-v=6", "--logtostderr"}, progressPort, resultDir),
+		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "--level=trace", "-v=6", "--logtostderr"}, progressPort, resultDir, p.Definition.Spec.Container.Env),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {


### PR DESCRIPTION
To allow users a way to specify env vars for the workers,
and therefore customize behavior, we copy the main set of
env vars from the plugin to the worker container. In the case
of conflicts, we prioritize our preset value to avoid breaking
the worker (e.g. if they try and override the address of the
aggregator).

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
The Sonobuoy worker (sidecar plugin) will now get have read-only access to all the env vars set for its corresponding plugin. This will enable some customization of worker behavior if needed to support other features.
```
