### PR TITLE
Improve version subcommand

### DIFF
--- a/cmd/sonobuoy/app/version.go
+++ b/cmd/sonobuoy/app/version.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -57,6 +58,8 @@ func runVersion(versionflags *versionFlags) func(cmd *cobra.Command, args []stri
 		fmt.Printf("MinimumKubeVersion: %s\n", buildinfo.MinimumKubeVersion)
 		fmt.Printf("MaximumKubeVersion: %s\n", buildinfo.MaximumKubeVersion)
 		fmt.Printf("GitSHA: %s\n", buildinfo.GitSHA)
+		fmt.Printf("GoVersion: %s\n", runtime.Version())
+		fmt.Printf("Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 		// Get Kubernetes version, this is last so that the regular version information
 		// will be shown even if the API server cannot be contacted and throws an error


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Go version and platform information to the version subcommand output

```
~/s/v/sonobuoy on 🌱 improve-version-subcommand (ddda7b1) [++(1)] on ⛵ dev () 
❯ GOOS=darwin GOARCH=arm64 go install
~/s/v/sonobuoy on 🌱 improve-version-subcommand (ddda7b1) [++(1)] on ⛵ dev () 
❯ sonobuoy version --kubeconfig ~/.kube/config
Sonobuoy Version: v0.56.0
MinimumKubeVersion: 1.17.0
MaximumKubeVersion: 1.99.99
GitSHA: 
GoVersion: go1.17.6
Platform: darwin/arm64
API Version:  v1.21.1
```

**Which issue(s) this PR fixes**
- Fixes None

**Special notes for your reviewer**:

None

**Release note**:
```
Adds Go version and platform information to the version subcommand output
```
