### PR TITLE
Modify reader code to work on unzipped results as well

### DIFF
--- a/pkg/client/results/reader_unix.go
+++ b/pkg/client/results/reader_unix.go
@@ -1,0 +1,48 @@
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || nacl || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris
+
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package results
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// fileInfoToReader takes the given FileInfo object and tries to return a reader
+// for the data. In the case of normal FileInfo objects (e.g. from os.Stat())
+// you need to provide the full path to the file so it can be opened since the
+// FileInfo object only contains the name but not the directory.
+func fileInfoToReader(info os.FileInfo, path string) (io.Reader, error) {
+	switch v := info.Sys().(type) {
+	case io.Reader:
+		return info.Sys().(io.Reader), nil
+	case syscall.Stat_t, *syscall.Stat_t:
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to open path %v", path)
+		}
+		return f, nil
+	default:
+		return nil, fmt.Errorf("info.Sys() (name=%v) is type %v and unable to be used as an io.Reader", info.Name(), v)
+	}
+}

--- a/pkg/client/results/reader_windows.go
+++ b/pkg/client/results/reader_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package results
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// fileInfoToReader takes the given FileInfo object and tries to return a reader
+// for the data. In the case of normal FileInfo objects (e.g. from os.Stat())
+// you need to provide the full path to the file so it can be opened since the
+// FileInfo object only contains the name but not the directory.
+func fileInfoToReader(info os.FileInfo, path string) (io.Reader, error) {
+	switch v := info.Sys().(type) {
+	case io.Reader:
+		return info.Sys().(io.Reader), nil
+	default:
+		return nil, fmt.Errorf("info.Sys() (name=%v) is type %v and unable to be used as an io.Reader", info.Name(), v)
+	}
+}

--- a/pkg/discovery/summary_test.go
+++ b/pkg/discovery/summary_test.go
@@ -17,16 +17,12 @@ limitations under the License.
 package discovery
 
 import (
-	"testing"
-        "encoding/json"
 	"bytes"
+	"encoding/json"
 	"flag"
-        "path/filepath"
 	"io/ioutil"
-)
-
-const (
-
+	"path/filepath"
+	"testing"
 )
 
 var update = flag.Bool("update", false, "update the .golden files")
@@ -39,11 +35,11 @@ func TestReadHealthSummary(t *testing.T) {
 
 	goldenFilePath := filepath.Join(tarballRootDir, "summary_test.golden")
 
-	got, err :=  ReadHealthSummary(tarballRootDir)
+	got, err := ReadHealthSummary(tarballRootDir)
 	if err != nil {
 		t.Fatalf("\n\nReadHealthSummary('%s') failed with error %s\n", tarballRootDir, err)
 	}
-	
+
 	gotJson, err := json.Marshal(got)
 	if err != nil {
 		t.Fatalf("\n\nThe value returned from ReadHealthSummary('%s') fails to be marshalled to json: %s\n", tarballRootDir, err)
@@ -56,8 +52,8 @@ func TestReadHealthSummary(t *testing.T) {
 		if err != nil {
 			t.Fatalf("\n\nFailed to read golden file from '%s': %s\n", goldenFilePath, err)
 		}
-		if ! bytes.Equal(gotJson, expectedJson) {
-			t.Fatalf("\n\nExpected %s, got %s\n", expectedJson, gotJson)
+		if !bytes.Equal(gotJson, expectedJson) {
+			t.Fatalf("\n\nExpected %s,\n     got %s\n", expectedJson, gotJson)
 		}
 	}
 }


### PR DESCRIPTION
The code for the results reader was made to read the tarball without
opening it but it should also work on unzipped results. This allows
more reuse of the methods, a centralized place to put results structure
information, and will allow us to expand `results` to process an unzipped
directory as well.

Signed-off-by: John Schnake <jschnake@vmware.com>

- Fixes #1617