### PR TITLE
Add function for walking item tree

### DIFF
--- a/pkg/client/results/item.go
+++ b/pkg/client/results/item.go
@@ -110,3 +110,21 @@ func (i *Item) GetSubTreeByName(root string) *Item {
 func IsTimeoutErr(i Item) bool {
 	return strings.Contains(fmt.Sprint(i.Details["error"]), "timeout")
 }
+
+// IsLeaf returns true if the item has no sub-items (children). Typically
+// refers to individual tests whereas non-leaf nodes more commonly refer to
+// suites, nodes, or files rolled up from the individual tests.
+func (i *Item) IsLeaf() bool {
+	return len(i.Items) == 0
+}
+
+// Walk will do a depth-first traversal of the Item tree calling fn on each
+// item. If an error is returned, traversal will stop.
+func (i *Item) Walk(fn func(*Item) error) error {
+	for subIndex := range i.Items {
+		if err := i.Items[subIndex].Walk(fn); err != nil {
+			return err
+		}
+	}
+	return fn(i)
+}

--- a/pkg/client/results/item_test.go
+++ b/pkg/client/results/item_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright the Sonobuoy contributors 2022
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package results
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestItem_Walk(t *testing.T) {
+	getItem := func() Item {
+		return Item{
+			Name:   "1",
+			Status: StatusFailed,
+			Items: []Item{
+				{
+					Name:   "2",
+					Status: StatusPassed,
+				},
+				{
+					Name:   "3",
+					Status: StatusFailed,
+				},
+				{
+					Name:   "4",
+					Status: StatusPassed,
+					Items: []Item{
+						{
+							Name:   "5",
+							Status: StatusFailed,
+							Items:  []Item{},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	sb := strings.Builder{}
+	testCases := []struct {
+		desc         string
+		input        Item
+		fn           func(*Item) error
+		expectErr    error
+		expectString string
+	}{
+		{
+			desc:  "Each item is visited in the proper order",
+			input: getItem(),
+			fn: func(i *Item) error {
+				sb.WriteString(i.Name)
+				return nil
+			},
+			expectString: "23541",
+		}, {
+			desc:  "Error stops traversal",
+			input: getItem(),
+			fn: func(i *Item) error {
+				sb.WriteString(i.Name)
+				if i.Name == "3" {
+					return errors.New("stop at 3")
+				}
+				return nil
+			},
+			expectErr:    errors.New("stop at 3"),
+			expectString: "23",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sb.Reset()
+			err := tc.input.Walk(tc.fn)
+			switch {
+			case tc.expectErr == nil && err == nil:
+			case tc.expectErr == nil && err != nil:
+				t.Errorf("Expected nil error but got %v", err)
+			case tc.expectErr != nil && err == nil:
+				t.Errorf("Expected error %v but got nil", err)
+			case tc.expectErr.Error() != err.Error():
+				t.Errorf("Expected error %v but got %v", tc.expectErr, err)
+			}
+
+			if tc.expectString != sb.String() {
+				t.Errorf("Expected %q but got %q", tc.expectString, sb.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
For processing results it can be useful to be able to
traverse the entire results tree. Rather than implement
this each time in projects, implementing it here.

Signed-off-by: John Schnake <jschnake@vmware.com>

