### PR TITLE
Update linter and fix staticcheck issues

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: golangci-lint run
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v1.45
           skip-pkg-cache: true
           skip-build-cache: true
           args: --timeout=2m0s -v

--- a/cmd/sonobuoy/app/imagepullpolicy.go
+++ b/cmd/sonobuoy/app/imagepullpolicy.go
@@ -19,8 +19,9 @@ package app
 import (
 	"fmt"
 	"sort"
-	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -37,7 +38,7 @@ func (i *ImagePullPolicy) Type() string   { return "ImagePullPolicy" }
 
 func (i *ImagePullPolicy) Set(str string) error {
 	// Allow lowercase pull policies in command line
-	upcase := strings.Title(str)
+	upcase := cases.Title(language.AmericanEnglish).String(str)
 	policy, ok := pullPolicyMap[upcase]
 	if !ok {
 		return fmt.Errorf("unknown pull policy %q", str)

--- a/cmd/sonobuoy/app/rbac.go
+++ b/cmd/sonobuoy/app/rbac.go
@@ -19,9 +19,10 @@ package app
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -60,7 +61,7 @@ func (r *RBACMode) Type() string { return "RBACMode" }
 // Set the RBACMode to the given string, or error if it's not a known RBAC mode.
 func (r *RBACMode) Set(str string) error {
 	// Allow lowercase on the command line
-	upcase := strings.Title(str)
+	upcase := cases.Title(language.AmericanEnglish).String(str)
 	mode, ok := rbacModeMap[upcase]
 	if !ok {
 		return fmt.Errorf("unknown RBAC mode %s", str)

--- a/cmd/sonobuoy/app/wait.go
+++ b/cmd/sonobuoy/app/wait.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"fmt"
-	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type WaitOutputMode string
@@ -28,7 +30,7 @@ func (w *WaitOutputMode) Type() string { return "string" }
 // Set the WaitOutputMode to the given string, or error if it's not a known WaitOutputMode mode.
 func (w *WaitOutputMode) Set(str string) error {
 	// Allow lowercase on the command line
-	upcase := strings.Title(str)
+	upcase := cases.Title(language.AmericanEnglish).String(str)
 	mode, ok := waitOutputModeMap[upcase]
 	if !ok {
 		return fmt.Errorf("unknown wait output mode %s", str)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
+	golang.org/x/text v0.3.4
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.21.3


### PR DESCRIPTION
Linter was complaining about requiring an update.
Updating it revealed issues with strings.Title which
have been fixed here.

Signed-off-by: John Schnake <jschnake@vmware.com>