### PR TITLE
Add configmaps to sidecars

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -170,6 +170,16 @@ func (*SonobuoyClient) GenerateManifestAndPlugins(cfg *GenConfig) ([]byte, []*ma
 					}},
 				},
 			})
+		// Sidecars get mounts too so that they can leverage the feature too.
+		if p.PodSpec != nil && len(p.PodSpec.Containers) > 0 {
+			for i := range p.PodSpec.Containers {
+				p.PodSpec.Containers[i].VolumeMounts = append(p.Spec.VolumeMounts,
+					corev1.VolumeMount{
+						Name:      fmt.Sprintf("sonobuoy-%v-vol", p.SonobuoyConfig.PluginName),
+						MountPath: sonobuoyDefaultConfigDir,
+					})
+			}
+		}
 		p.Spec.VolumeMounts = append(p.Spec.VolumeMounts,
 			corev1.VolumeMount{
 				Name:      fmt.Sprintf("sonobuoy-%v-vol", p.SonobuoyConfig.PluginName),


### PR DESCRIPTION
Currently when a configmap is defined in a plugin
it is only added to the main container and not the
sidecars. This adds it in the same fashion to the
others.

Signed-off-by: John Schnake <jschnake@vmware.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
