### PR TITLE
Export post processing

### DIFF
--- a/pkg/client/results/gojson.go
+++ b/pkg/client/results/gojson.go
@@ -57,7 +57,7 @@ type testEvent struct {
 	Output  string
 }
 
-func gojsonProcessFile(pluginDir, currentFile string) (Item, error) {
+func GojsonProcessFile(pluginDir, currentFile string) (Item, error) {
 	relPath, err := filepath.Rel(pluginDir, currentFile)
 	if err != nil {
 		logrus.Errorf("Error making path %q relative to %q: %v", pluginDir, currentFile, err)

--- a/pkg/client/results/junit.go
+++ b/pkg/client/results/junit.go
@@ -166,7 +166,7 @@ func JUnitErrored(testCase JUnitTestCase) bool {
 	return testCase.SkipMessage == nil && testCase.Failure == nil && testCase.ErrorMessage != nil
 }
 
-func junitProcessFile(pluginDir, currentFile string) (Item, error) {
+func JunitProcessFile(pluginDir, currentFile string) (Item, error) {
 	relPath, err := filepath.Rel(pluginDir, currentFile)
 	if err != nil {
 		logrus.Errorf("Error making path %q relative to %q: %v", pluginDir, currentFile, err)

--- a/pkg/client/results/raw.go
+++ b/pkg/client/results/raw.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// rawProcessFile will return an Item object with the File value set to the path in question. If the
+// RawProcessFile will return an Item object with the File value set to the path in question. If the
 // file is unable to be stat'd then the status of the Item is StatusFailed (StatusPassed otherwise).
-func rawProcessFile(pluginDir, currentFile string) (Item, error) {
+func RawProcessFile(pluginDir, currentFile string) (Item, error) {
 	relPath, err := filepath.Rel(pluginDir, currentFile)
 	if err != nil {
 		logrus.Errorf("Error making path %q relative to %q: %v", pluginDir, currentFile, err)


### PR DESCRIPTION
If we want any other plugin/library to be able to
translate files into the manual output, we need to
export the functions and types necessary.

**Which issue(s) this PR fixes**
- Fixes #1664 