### PR TITLE
Have 'images' commands respect env vars

### DIFF
--- a/pkg/image/docker/client.go
+++ b/pkg/image/docker/client.go
@@ -30,16 +30,21 @@ type Docker interface {
 	Tag(src, dest string, retries int) error
 	Rmi(image string, retries int) error
 	Save(images []string, filename string) error
-	Run(image string, entryPoint string, args ...string) ([]string, error)
+	Run(image string, entryPoint string, env map[string]string, args ...string) ([]string, error)
 }
 
 type LocalDocker struct {
 }
 
-func (l LocalDocker) Run(image string, entryPoint string, args ...string) ([]string, error) {
+func (l LocalDocker) Run(image string, entryPoint string, env map[string]string, args ...string) ([]string, error) {
 	dockerArgs := []string{"run", "--rm"}
 	if len(entryPoint) > 0 {
 		dockerArgs = append(dockerArgs, fmt.Sprintf("--entrypoint=%v", entryPoint))
+	}
+	if len(env) > 0 {
+		for k, v := range env {
+			dockerArgs = append(dockerArgs, fmt.Sprintf("-e=%v=%v", k, v))
+		}
 	}
 	dockerArgs = append(dockerArgs, image)
 	dockerArgs = append(dockerArgs, args...)

--- a/pkg/image/docker_client.go
+++ b/pkg/image/docker_client.go
@@ -109,8 +109,8 @@ func (i DockerClient) DeleteImages(images []string, retries int) []error {
 	return errs
 }
 
-func (i DockerClient) RunImage(image string, entryPoint string, args ...string) ([]string, error) {
-	output, err := i.dockerClient.Run(image, entryPoint, args...)
+func (i DockerClient) RunImage(image string, entryPoint string, env map[string]string, args ...string) ([]string, error) {
+	output, err := i.dockerClient.Run(image, entryPoint, env, args...)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/image/docker_client_test.go
+++ b/pkg/image/docker_client_test.go
@@ -34,8 +34,8 @@ type FakeDockerClient struct {
 	deleteFails bool
 }
 
-func (l FakeDockerClient) Run(image string, entryPoint string, args ...string) ([]string, error) {
-	return l.Run(image, entryPoint, args...)
+func (l FakeDockerClient) Run(image string, entryPoint string, env map[string]string, args ...string) ([]string, error) {
+	return l.Run(image, entryPoint, nil, args...)
 }
 
 func (l FakeDockerClient) PullIfNotPresent(image string, retries int) error {

--- a/pkg/image/dryrun_client.go
+++ b/pkg/image/dryrun_client.go
@@ -24,7 +24,7 @@ import (
 // be performed rather than performing them.
 type DryRunClient struct{}
 
-func (i DryRunClient) RunImage(image string, entryPoint string, args ...string) ([]string, error) {
+func (i DryRunClient) RunImage(image string, entryPoint string, env map[string]string, args ...string) ([]string, error) {
 	// Called from collectPluginsImages, retrieve e2e images
 	// Return empty list instead of outdated info
 	return []string{}, nil

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -22,5 +22,5 @@ type Client interface {
 	PushImages(images []TagPair, retries int) []error
 	DownloadImages(images []string, version string) (string, error)
 	DeleteImages(images []string, retries int) []error
-	RunImage(image string, entrypoint string, args ...string) ([]string, error)
+	RunImage(image string, entrypoint string, env map[string]string, args ...string) ([]string, error)
 }


### PR DESCRIPTION
This just passes env vars down the command to when we actually run
any images. This allows us to set KUBE_TEST_REPO as an env var
and see the images for which k8s will look for those images.

Fixes: #1678

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
KUBE_TEST_REPO can now be set when listing images, helping you get the proper tags for your images if you intend to utilize that feature.
```
