### PR TITLE
add url flag to set url for plugin

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -134,6 +134,11 @@ func NewCmdGenPluginDef() *cobra.Command {
 		"Description for the plugin",
 	)
 
+	genPluginSet.StringVarP(
+		&genPluginOpts.def.SonobuoyConfig.SourceURL, "url", "u", "",
+		"URL for the plugin",
+	)
+
 	AddShowDefaultPodSpecFlag(&genPluginOpts.showDefaultPodSpec, genPluginSet)
 
 	cmd.Flags().AddFlagSet(genPluginSet)


### PR DESCRIPTION
Signed-off-by: DiptoChakrabarty <diptochuck123@gmail.com>


**What this PR does / why we need it**: adds a flag to set the url for a  plugin 

**Which issue(s) this PR fixes**
- Fixes #1648 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
