### PR TITLE
Always upload artifacts

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -129,6 +129,7 @@ jobs:
           load_test_images_into_cluster
           VERBOSE=true SONOBUOY_CLI=../../build/linux/amd64/sonobuoy integration
       - name: Save artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: sonobuoy-test-archives-${{ github.run_id }}


### PR DESCRIPTION
Otherwise failures in tests cause no artifacts, which is obviously a problem
when we want to investigate failures.

Fixes #1698

Signed-off-by: John Schnake <jschnake@vmware.com>