### PR TITLE
Remove empty resources from gen plugin

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -163,13 +164,13 @@ func genPluginDefWrapper(cfg *GenPluginDefConfig) func(cmd *cobra.Command, args 
 			errlog.LogError(err)
 			os.Exit(1)
 		}
-		fmt.Println(string(s))
+		fmt.Println(s)
 	}
 }
 
 // genPluginDef returns the YAML for the plugin which Sonobuoy would expect as
 // a configMap in order to run/gen a typical run.
-func genPluginDef(cfg *GenPluginDefConfig) ([]byte, error) {
+func genPluginDef(cfg *GenPluginDefConfig) (string, error) {
 	// Copy the validated value to the actual field.
 	cfg.def.SonobuoyConfig.Driver = cfg.driver.String()
 
@@ -202,7 +203,7 @@ func genPluginDef(cfg *GenPluginDefConfig) ([]byte, error) {
 	for _, v := range cfg.configMapFiles {
 		fData, err := os.ReadFile(v)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read file %q", v)
+			return "", errors.Wrapf(err, "failed to read file %q", v)
 		}
 		base := filepath.Base(v)
 		cfg.def.ConfigMap[base] = string(fData)
@@ -211,11 +212,11 @@ func genPluginDef(cfg *GenPluginDefConfig) ([]byte, error) {
 	// Ensure a config with this plugin would validate
 	gc := client.GenConfig{StaticPlugins: []*manifest.Manifest{&cfg.def}}
 	if err := gc.Validate(); err != nil {
-		return nil, errors.Wrap(err, "plugin failed validation")
+		return "", errors.Wrap(err, "plugin failed validation")
 	}
 
 	yaml, err := kuberuntime.Encode(manifest.Encoder, &cfg.def)
-	return yaml, errors.Wrap(err, "serializing as YAML")
+	return prettifyPlugin(yaml), errors.Wrap(err, "serializing as YAML")
 }
 
 func NewCmdGenE2E() *cobra.Command {
@@ -257,7 +258,7 @@ func genManifestForPlugin(genflags *genFlags, pluginName string) func(cmd *cobra
 				if err != nil {
 					return errors.Wrap(err, "error attempting to serialize plugin")
 				}
-				fmt.Print(string(yaml))
+				fmt.Print(prettifyPlugin(yaml))
 			}
 		}
 		return nil
@@ -274,4 +275,11 @@ func NewCmdGenSystemdLogs() *cobra.Command {
 	}
 	cmd.Flags().AddFlagSet(GenFlagSet(&genSystemdLogsflags, EnabledRBACMode))
 	return cmd
+}
+
+// prettifyPlugin just apply any repeated modifications we want to make to the default
+// serialization.
+func prettifyPlugin(b []byte) string {
+	emptyResource := []byte("  resources: {}\n")
+	return string(bytes.ReplaceAll(b, emptyResource, nil))
 }

--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -143,13 +143,13 @@ func TestPluginGenDef(t *testing.T) {
 			}
 
 			if *update {
-				ioutil.WriteFile(tC.expectFile, manifest, 0666)
+				ioutil.WriteFile(tC.expectFile, []byte(manifest), 0666)
 			} else {
 				fileData, err := ioutil.ReadFile(tC.expectFile)
 				if err != nil {
 					t.Fatalf("Failed to read golden file %v: %v", tC.expectFile, err)
 				}
-				if !bytes.Equal(fileData, manifest) {
+				if !bytes.Equal(fileData, []byte(manifest)) {
 					t.Errorf("Expected manifest to equal goldenfile: %v but instead got:\n\n%v", tC.expectFile, string(manifest))
 				}
 			}

--- a/cmd/sonobuoy/app/testdata/pluginDef-container.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-container.golden
@@ -8,4 +8,3 @@ spec:
   - ./run.sh
   image: img
   name: "n"
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
@@ -17,4 +17,3 @@ sonobuoy-config:
   plugin-name: "n"
 spec:
   name: ""
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-env.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-env.golden
@@ -6,4 +6,3 @@ spec:
   - name: FOO
     value: bar
   name: ""
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-nodeselector-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-nodeselector-default-podspec.golden
@@ -18,4 +18,3 @@ sonobuoy-config:
   plugin-name: "n"
 spec:
   name: ""
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-nodeselector.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-nodeselector.golden
@@ -18,4 +18,3 @@ sonobuoy-config:
   plugin-name: "n"
 spec:
   name: ""
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
@@ -11,4 +11,3 @@ spec:
     value: '- bar'
   image: img:v1
   name: n - foo
-  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-sonoconfig.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-sonoconfig.golden
@@ -3,4 +3,3 @@ sonobuoy-config:
   plugin-name: "n"
 spec:
   name: ""
-  resources: {}

--- a/test/integration/testdata/gen-plugin-e2e-configmap.golden
+++ b/test/integration/testdata/gen-plugin-e2e-configmap.golden
@@ -45,7 +45,6 @@ spec:
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
-  resources: {}
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
+++ b/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
@@ -46,7 +46,6 @@ spec:
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
-  resources: {}
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/test/integration/testdata/gen-plugin-e2e.golden
+++ b/test/integration/testdata/gen-plugin-e2e.golden
@@ -45,7 +45,6 @@ spec:
   image: k8s.gcr.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
-  resources: {}
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results


### PR DESCRIPTION
A tiny bit of refactoring to ensure we hit that path and test it
as well.

Partially addresses: #1649

Signed-off-by: John Schnake <jschnake@vmware.com>

**Special notes for your reviewer**:
`sonobuoy gen plugin e2e` and `systemd-logs` still shows the mount because in order to get those it runs through the full `gen` process and applies the mount in the same way it does when sonobuoy consumes any other plugin.

Unnecessary but less of an issue IMO.
