### PR TITLE
Include Image name in image pull error message

### DIFF
--- a/pkg/plugin/driver/utils/utils.go
+++ b/pkg/plugin/driver/utils/utils.go
@@ -68,7 +68,6 @@ func IsPodFailing(pod *v1.Pod) (bool, string) {
 
 		// Check if it can't fetch its image within the maximum wait time
 		if waiting := cstatus.State.Waiting; waiting != nil && pod.Status.StartTime != nil {
-			_ := pod.Spec.Containers.
 			elapsedPodTime := time.Since(pod.Status.StartTime.Time)
 			if elapsedPodTime > maxWaitForImageTime && (waiting.Reason == "ImagePullBackOff" || waiting.Reason == "ErrImagePull") {
 				errstr := fmt.Sprintf("Failed to pull image %v for container %v within %v. Container is in state %v", cstatus.Image, cstatus.Name, maxWaitForImageTime, waiting.Reason)

--- a/pkg/plugin/driver/utils/utils.go
+++ b/pkg/plugin/driver/utils/utils.go
@@ -71,7 +71,7 @@ func IsPodFailing(pod *v1.Pod) (bool, string) {
 			_ := pod.Spec.Containers.
 			elapsedPodTime := time.Since(pod.Status.StartTime.Time)
 			if elapsedPodTime > maxWaitForImageTime && (waiting.Reason == "ImagePullBackOff" || waiting.Reason == "ErrImagePull") {
-				errstr := fmt.Sprintf("Failed to pull image %v for container %v within %v. Container is in state %v",cstatus.Image, cstatus.Name, maxWaitForImageTime, waiting.Reason)
+				errstr := fmt.Sprintf("Failed to pull image %v for container %v within %v. Container is in state %v", cstatus.Image, cstatus.Name, maxWaitForImageTime, waiting.Reason)
 				return true, errstr
 			}
 		}

--- a/pkg/plugin/driver/utils/utils.go
+++ b/pkg/plugin/driver/utils/utils.go
@@ -68,9 +68,10 @@ func IsPodFailing(pod *v1.Pod) (bool, string) {
 
 		// Check if it can't fetch its image within the maximum wait time
 		if waiting := cstatus.State.Waiting; waiting != nil && pod.Status.StartTime != nil {
+			_ := pod.Spec.Containers.
 			elapsedPodTime := time.Since(pod.Status.StartTime.Time)
 			if elapsedPodTime > maxWaitForImageTime && (waiting.Reason == "ImagePullBackOff" || waiting.Reason == "ErrImagePull") {
-				errstr := fmt.Sprintf("Failed to pull image for container %v within %v. Container is in state %v", cstatus.Name, maxWaitForImageTime, waiting.Reason)
+				errstr := fmt.Sprintf("Failed to pull image %v for container %v within %v. Container is in state %v",cstatus.Image, cstatus.Name, maxWaitForImageTime, waiting.Reason)
 				return true, errstr
 			}
 		}

--- a/pkg/plugin/driver/utils/utils_test.go
+++ b/pkg/plugin/driver/utils/utils_test.go
@@ -109,12 +109,13 @@ func TestPodFailing(t *testing.T) {
 		}, {
 			desc:          "ImagePullBackOff is considered a failure if elapsed time greater than wait window",
 			expectFailing: true,
-			expectMsg:     "Failed to pull image for container error-container within 5m0s. Container is in state ImagePullBackOff",
+			expectMsg:     "Failed to pull image random-image for container error-container within 5m0s. Container is in state ImagePullBackOff",
 			pod: fromGoodPod(func(p *corev1.Pod) *corev1.Pod {
 				p.Status.StartTime = &metav1.Time{Time: time.Now().Add(-maxWaitForImageTime)}
 				p.Status.ContainerStatuses = []corev1.ContainerStatus{
 					{
-						Name: "error-container",
+						Name:  "error-container",
+						Image: "random-image",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
 								Reason: "ImagePullBackOff",
@@ -126,12 +127,13 @@ func TestPodFailing(t *testing.T) {
 		}, {
 			desc:          "ErrImagePull is considered a failure if elapsed time greater than wait window",
 			expectFailing: true,
-			expectMsg:     "Failed to pull image for container error-container within 5m0s. Container is in state ErrImagePull",
+			expectMsg:     "Failed to pull image random-image for container error-container within 5m0s. Container is in state ErrImagePull",
 			pod: fromGoodPod(func(p *corev1.Pod) *corev1.Pod {
 				p.Status.StartTime = &metav1.Time{Time: time.Now().Add(-maxWaitForImageTime)}
 				p.Status.ContainerStatuses = []corev1.ContainerStatus{
 					{
-						Name: "error-container",
+						Name:  "error-container",
+						Image: "random-image",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
 								Reason: "ErrImagePull",


### PR DESCRIPTION
**What this PR does / why we need it**:
This includes the image name which causes the errImagepull error to make the error message more meaningful
**Which issue(s) this PR fixes**
- Fixes #1707 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
