### PR TITLE
Fix skopeo login for image push issue

### DIFF
--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -219,12 +219,13 @@ push_images() {
         docker push "$REGISTRY/$TARGET:$arch-$IMAGE_BRANCH"
         docker push "$REGISTRY/$TARGET:$arch-$IMAGE_VERSION"
     done
-    
+
     export REGISTRY_AUTH_FILE=$(pwd)/auth.json
-    skopeo login --username $DOCKERHUB_USER --password $DOCKERHUB_TOKEN registry.hub.docker.com/$DOCKERHUB_USER
+    skopeo login --username $DOCKERHUB_USER --password $DOCKERHUB_TOKEN registry.hub.docker.com/$REGISTRY
+
     for VERSION in "${WINVERSIONS[@]}"; do
-        skopeo copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_BRANCH"
-        skopeo copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_VERSION"
+        skopeo --debug copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_BRANCH"
+        skopeo --debug copy docker-archive://$(pwd)/build/windows/$WIN_ARCH/$VERSION/sonobuoy-img-win-$WIN_ARCH-$VERSION-$GITHUB_RUN_ID.tar "docker://registry.hub.docker.com/$REGISTRY/$TARGET:win-$WIN_ARCH-$VERSION-$IMAGE_VERSION"
     done
 }
 


### PR DESCRIPTION
Locally I reproduced the bug and was able to fix it by changing the
skopeo login to the $REGISTRY and not to the $DOCKERHUB_USER.

This begs the question: why did it work in the past? Unsure of the root
cause but this seemed to remedy it.

Also added debug info so that we can better diagnose the issue in the
future.

Fixes #1730

Signed-off-by: John Schnake <jschnake@vmware.com>