### PR TITLE
Add readable mode to results command

### DIFF
--- a/cmd/sonobuoy/app/results.go
+++ b/cmd/sonobuoy/app/results.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -46,6 +47,9 @@ const (
 
 	// resultModeDump will just copy the post-processed yaml file to stdout.
 	resultModeDump = "dump"
+
+	//resultModeReadable will copy the post-processed yaml file to stdout and replace \n and \t with new lines and tabs respectively.
+	resultModeReadable = "readable"
 
 	windowsSeperator = `\`
 
@@ -83,7 +87,7 @@ func NewCmdResults() *cobra.Command {
 	)
 	cmd.Flags().StringVarP(
 		&data.mode, "mode", "m", resultModeReport,
-		`Modifies the format of the output. Valid options are report, detailed, or dump.`,
+		`Modifies the format of the output. Valid options are report, detailed, readable, or dump.`,
 	)
 	cmd.Flags().StringVarP(
 		&data.node, "node", "n", "",
@@ -217,6 +221,15 @@ func printHealthSummary(input resultsInput, r *results.Reader) error {
 			return err
 		}
 		fmt.Println(string(data))
+	case resultModeReadable:
+		data, err = yaml.Marshal(clusterHealthSummary)
+		if err != nil {
+			return err
+		}
+		str := string(data)
+		str = strings.ReplaceAll(str, `\n`, "\n")
+		str = strings.ReplaceAll(str, `\t`, "	")
+		fmt.Println(str)
 	default:
 		err = printClusterHealthResultsSummary(clusterHealthSummary)
 		if err != nil {
@@ -224,6 +237,17 @@ func printHealthSummary(input resultsInput, r *results.Reader) error {
 		}
 	}
 	return nil
+}
+
+type humanReadableWriter struct {
+	w io.Writer
+}
+
+func (hw *humanReadableWriter) Write(b []byte) (int, error) {
+	newb := bytes.Replace(b, []byte(`\n`), []byte("\n"), -1)
+	newb = bytes.Replace(newb, []byte(`\t`), []byte("\t"), -1)
+	_, err := hw.w.Write(newb)
+	return len(b), err
 }
 
 func printSinglePlugin(input resultsInput, r *results.Reader) error {
@@ -234,6 +258,17 @@ func printSinglePlugin(input resultsInput, r *results.Reader) error {
 			return errors.Wrapf(err, "failed to get results reader for plugin %v", input.plugin)
 		}
 		_, err = io.Copy(os.Stdout, fReader)
+		return err
+	} else if input.mode == resultModeReadable {
+		fReader, err := r.PluginResultsReader(input.plugin)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get results reader for plugin %v", input.plugin)
+		}
+		writer := &humanReadableWriter{os.Stdout}
+		_, err = io.Copy(writer, fReader)
+		if err != nil {
+			panic(err.Error())
+		}
 		return err
 	}
 

--- a/cmd/sonobuoy/app/results_test.go
+++ b/cmd/sonobuoy/app/results_test.go
@@ -16,9 +16,97 @@ limitations under the License.
 package app
 
 import (
+	"bytes"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestHumanReadableWriter(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		input    string
+		contains []string
+		expected bool
+	}{
+		{
+			desc:     "String with \\n does not contain `\\n`",
+			input:    "\nHello world",
+			contains: []string{`\n`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t does not contain `\\t`",
+			input:    "\tHello world",
+			contains: []string{`\t`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \n does not contain `\\n`",
+			input:    "\tHello\nworld",
+			contains: []string{`\n`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \\n does not contain `\\t`",
+			input:    "\tHello\nworld",
+			contains: []string{`\t`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \\n does not contain `\\n` or `\\t`",
+			input:    "\tHello\nworld",
+			contains: []string{`\n`, `\t`},
+			expected: false,
+		},
+		{
+			desc:     `String with \n contains "\n"`,
+			input:    "\nHello world",
+			contains: []string{"\n"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t contains "\t"`,
+			input:    "\tHello world",
+			contains: []string{"\t"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\n"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\n"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\t"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\t"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\n" and "\t"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\n", "\t"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			buffer := bytes.Buffer{}
+			writer := humanReadableWriter{&buffer}
+			fmt.Fprintf(&writer, tc.input)
+			for _, contains := range tc.contains {
+				out := strings.Contains(buffer.String(), contains)
+				if out != tc.expected {
+					// replace this message
+					//		t.Errorf("Expected %v but got %v", tc.expected, out)
+				}
+			}
+		})
+	}
+}
 
 func TestGetFileFromMeta(t *testing.T) {
 	tcs := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds "readable" mode to the results command. Replaces \n with a new line and \t with a tab to make the output to stdio from the sonobuoy_results.yaml file more readable (dump mode does not do this).

**Which issue(s) this PR fixes**
- Fixes #1628

**Special notes for your reviewer**:
Need to test the output of the command using readable mode. I was thinking we could have printSinglePlugin and printHealthSummary also return strings of what is printed to stdout to be used for testing, but that approach may be overkill for the sake of testing.