### PR TITLE
Add clusterRead to aggregator permissions help

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -165,7 +165,7 @@ func AddSecurityContextMode(mode *string, flags *pflag.FlagSet) {
 func AddAggregatorPermissionsFlag(mode *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		mode, aggregatorPermissionsFlag, "clusterAdmin",
-		"Type of aggregator permission to use in the cluster. Allowable values are [namespaced, clusterAdmin]",
+		"Type of aggregator permission to use in the cluster. Allowable values are [namespaceAdmin, clusterRead, clusterAdmin]",
 	)
 }
 

--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -10,7 +10,7 @@ Available Commands:
 
 Flags:
       --aggregator-node-selector nodeSelectors   Node selectors to add to the aggregator. Values can be given multiple times and are in the form key:value (default map[])
-      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaced, clusterAdmin] (default "clusterAdmin")
+      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaceAdmin, clusterRead, clusterAdmin] (default "clusterAdmin")
       --config Sonobuoy config                   Path to a sonobuoy configuration JSON file.
       --context string                           Context in the kubeconfig to use.
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -10,7 +10,7 @@ Available Commands:
 
 Flags:
       --aggregator-node-selector nodeSelectors   Node selectors to add to the aggregator. Values can be given multiple times and are in the form key:value (default map[])
-      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaced, clusterAdmin] (default "clusterAdmin")
+      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaceAdmin, clusterRead, clusterAdmin] (default "clusterAdmin")
       --config Sonobuoy config                   Path to a sonobuoy configuration JSON file.
       --context string                           Context in the kubeconfig to use.
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -10,7 +10,7 @@ Available Commands:
 
 Flags:
       --aggregator-node-selector nodeSelectors   Node selectors to add to the aggregator. Values can be given multiple times and are in the form key:value (default map[])
-      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaced, clusterAdmin] (default "clusterAdmin")
+      --aggregator-permissions string            Type of aggregator permission to use in the cluster. Allowable values are [namespaceAdmin, clusterRead, clusterAdmin] (default "clusterAdmin")
       --config Sonobuoy config                   Path to a sonobuoy configuration JSON file.
       --context string                           Context in the kubeconfig to use.
       --dns-namespace string                     The namespace to check for DNS pods during preflight checks. (default "kube-system")


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the help for the aggregator permissions flag to add the clusterRead value. Should have all of the correct permissions listed now.

**Which issue(s) this PR fixes**
- Fixes #1704