### PR TITLE
Download kubectl when testing locally

### DIFF
--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -363,6 +363,10 @@ load_test_images_into_cluster(){
 # tests so this will also build sonobuoy locally. A kind cluster won't be necessary.
 update_local() {
     set -x
+    # Download linux kubectl and move into default path for tests
+    curl --output ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
+    chmod +x ./kubectl
+
     # Redirect output so we can avoid clutter where go is telling us where -update
     # is not defined. Just printing out the packages at the end.
     go test $GOTARGET/cmd/... $GOTARGET/pkg/... -update > tmp_update.out


### PR DESCRIPTION
**What this PR does / why we need it**:
Download kubectl when testing locally (`update_local`), as it is done in `integration`.

**Which issue(s) this PR fixes**
- Fixes #1739

