### PR TITLE
Add readable mode to results command

### DIFF
--- a/cmd/sonobuoy/app/results_test.go
+++ b/cmd/sonobuoy/app/results_test.go
@@ -16,9 +16,96 @@ limitations under the License.
 package app
 
 import (
+	"bytes"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestHumanReadableWriter(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		input    string
+		contains []string
+		expected bool
+	}{
+		{
+			desc:     "String with \\n does not contain `\\n`",
+			input:    "\nHello world",
+			contains: []string{`\n`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t does not contain `\\t`",
+			input:    "\tHello world",
+			contains: []string{`\t`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \n does not contain `\\n`",
+			input:    "\tHello\nworld",
+			contains: []string{`\n`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \\n does not contain `\\t`",
+			input:    "\tHello\nworld",
+			contains: []string{`\t`},
+			expected: false,
+		},
+		{
+			desc:     "String with \\t and \\n does not contain `\\n` or `\\t`",
+			input:    "\tHello\nworld",
+			contains: []string{`\n`, `\t`},
+			expected: false,
+		},
+		{
+			desc:     `String with \n contains "\n"`,
+			input:    "\nHello world",
+			contains: []string{"\n"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t contains "\t"`,
+			input:    "\tHello world",
+			contains: []string{"\t"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\n"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\n"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\t"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\t"},
+			expected: true,
+		},
+		{
+			desc:     `String with \t and \n contains "\n" and "\t"`,
+			input:    "\tHello\nworld",
+			contains: []string{"\n", "\t"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			buffer := bytes.Buffer{}
+			writer := humanReadableWriter{&buffer}
+			fmt.Fprintf(&writer, tc.input)
+			for _, contains := range tc.contains {
+				out := strings.Contains(buffer.String(), contains)
+				if out != tc.expected {
+					t.Errorf("Expected output: %v", tc.expected)
+				}
+			}
+		})
+	}
+}
 
 func TestGetFileFromMeta(t *testing.T) {
 	tcs := []struct {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
-	golang.org/x/text v0.3.6
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
*What this PR does / why we need it:*
Adds "readable" mode to the results command. Replaces \n with a new line and \t with a tab to make the output to stdio from the sonobuoy_results.yaml file more readable (dump mode does not do this).

Which issue(s) this PR fixes

Fixes https://github.com/vmware-tanzu/sonobuoy/issues/1628

*Special notes for your reviewer:*
Need to test the output of the command using readable mode. I was thinking we could have printSinglePlugin and printHealthSummary also return strings of what is printed to stdout to be used for testing, but that approach may be overkill for the sake of testing.