### PR TITLE
Update plugin ordering to latest Sonobuoy version

### DIFF
--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -53,6 +53,11 @@ func (b *Base) GetName() string {
 	return b.Definition.SonobuoyConfig.PluginName
 }
 
+// GetOrder returns the order of this Job plugin.
+func (b *Base) GetOrder() int {
+	return b.Definition.SonobuoyConfig.Order
+}
+
 // GetSecretName gets a name for a secret based on the plugin name and session ID.
 func (b *Base) GetSecretName() string {
 	return fmt.Sprintf("sonobuoy-plugin-%s-%s", b.GetName(), b.GetSessionID())

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -85,6 +85,7 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 		ret = append(ret, plugin.ExpectedResult{
 			NodeName:   node.Name,
 			ResultType: p.GetName(),
+			Order:      p.Definition.SonobuoyConfig.Order,
 		})
 	}
 

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -71,7 +71,11 @@ func NewPlugin(dfn manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy,
 // a Job only launches one pod, only one result type is expected.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return []plugin.ExpectedResult{
-		{ResultType: p.GetName(), NodeName: plugin.GlobalResult},
+		{
+			ResultType: p.GetName(),
+			NodeName:   plugin.GlobalResult,
+			Order:      p.Definition.SonobuoyConfig.Order,
+		},
 	}
 }
 

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -50,6 +50,7 @@ type SonobuoyConfig struct {
 	// to the plugin source would be kept.
 	SourceURL string `json:"source-url,omitempty"`
 
+	Order int `json:"order,omitempty"`
 	objectKind
 }
 
@@ -62,6 +63,7 @@ func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 		ResultFiles:  s.ResultFiles,
 		SkipCleanup:  s.SkipCleanup,
 		objectKind:   objectKind{s.objectKind.gvk},
+		Order:        s.Order,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Plugins should be able to run in a predetermined order. Adds order key to sonobuoy-config (lower number has a higher priority)

**Which issue(s) this PR fixes**
- Fixes #1684