### PR TITLE
Simplify logic for status aggregation

### DIFF
--- a/pkg/client/results/item.go
+++ b/pkg/client/results/item.go
@@ -38,6 +38,9 @@ const (
 	// if another can not be determined.
 	StatusUnknown = "unknown"
 
+	// StatusEmpty is just the empty string; we equate this to StatusUnknown.
+	StatusEmpty = ""
+
 	// StatusTimeout is the key used when the plugin does not report results within the
 	// timeout period. It will be treated as a failure (e.g. its parent will be marked
 	// as a failure).

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/ds-manual-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-02/ds-manual-02.golden.json
@@ -1,20 +1,20 @@
 {
 "name": "ds-manual-02",
-"status": "status-from-manual-results-1: 2, status-from-manual-results-2: 2",
+"status": "status 2: 4",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "status-from-manual-results-1: 1, status-from-manual-results-2: 1",
+"status": "status 2: 2",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results-1.yaml",
-"status": "status-from-manual-results-1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node1/manual-results-1.yaml",
 "type": "file"
@@ -22,7 +22,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -38,7 +38,7 @@
 },
 {
 "name": "manual-results-2.yaml",
-"status": "status-from-manual-results-2",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node1/manual-results-2.yaml",
 "type": "file"
@@ -46,7 +46,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -64,14 +64,14 @@
 },
 {
 "name": "node2",
-"status": "status-from-manual-results-1: 1, status-from-manual-results-2: 1",
+"status": "status 2: 2",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results-1.yaml",
-"status": "status-from-manual-results-1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node2/manual-results-1.yaml",
 "type": "file"
@@ -79,7 +79,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -95,7 +95,7 @@
 },
 {
 "name": "manual-results-2.yaml",
-"status": "status-from-manual-results-2",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node2/manual-results-2.yaml",
 "type": "file"
@@ -103,7 +103,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/ds-manual-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-03/ds-manual-03.golden.json
@@ -1,20 +1,20 @@
 {
 "name": "ds-manual-03",
-"status": "status-from-manual-results",
+"status": "status 2: 2",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "status-from-manual-results",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results.yaml",
-"status": "status-from-manual-results",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node1/manual-results.yaml",
 "type": "file"
@@ -22,7 +22,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -40,14 +40,14 @@
 },
 {
 "name": "node2",
-"status": "status-from-manual-results",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results.yaml",
-"status": "status-from-manual-results",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node2/manual-results.yaml",
 "type": "file"
@@ -55,7 +55,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
@@ -1,20 +1,20 @@
 {
 "name": "ds-manual-04",
-"status": "status-from-default-sonobuoy-results",
+"status": "status 2: 2",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "status-from-default-sonobuoy-results",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "sonobuoy_results.yaml",
-"status": "status-from-default-sonobuoy-results",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node1/sonobuoy_results.yaml",
 "type": "file"
@@ -22,7 +22,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -40,14 +40,14 @@
 },
 {
 "name": "node2",
-"status": "status-from-default-sonobuoy-results",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "sonobuoy_results.yaml",
-"status": "status-from-default-sonobuoy-results",
+"status": "status 2: 1",
 "meta": {
 "file": "results/node2/sonobuoy_results.yaml",
 "type": "file"
@@ -55,7 +55,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "status 2: 1",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-arbitrary-details/ds-manual-arbitrary-details.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-arbitrary-details/ds-manual-arbitrary-details.golden.json
@@ -1,20 +1,20 @@
 {
 "name": "ds-manual-arbitrary-details",
-"status": "status-from-manual-results",
+"status": "status 1: 2",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results-arbitrary-details.yaml",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "file": "results/node1/manual-results-arbitrary-details.yaml",
 "type": "file"
@@ -42,14 +42,14 @@
 },
 {
 "name": "node2",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "type": "node"
 },
 "items": [
 {
 "name": "manual-results-arbitrary-details.yaml",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "file": "results/node2/manual-results-arbitrary-details.yaml",
 "type": "file"

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-02/job-manual-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-02/job-manual-02.golden.json
@@ -1,13 +1,13 @@
 {
 "name": "job-manual-02",
-"status": "custom status: 1, different custom status: 1",
+"status": "passed",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "manual-results-1.yaml",
-"status": "different custom status",
+"status": "passed",
 "meta": {
 "file": "results/global/manual-results-1.yaml",
 "type": "file"
@@ -15,7 +15,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "passed",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -23,7 +23,7 @@
 "items": [
 {
 "name": "Manual suite name",
-"status": "status 2",
+"status": "passed",
 "items": [
 {
 "name": "Manual test name",
@@ -37,7 +37,7 @@
 },
 {
 "name": "manual-results-2.yaml",
-"status": "custom status",
+"status": "passed",
 "meta": {
 "file": "results/global/manual-results-2.yaml",
 "type": "file"
@@ -45,7 +45,7 @@
 "items": [
 {
 "name": "Another test file",
-"status": "status 1",
+"status": "passed",
 "meta": {
 "file": "results/global/junit_02.xml",
 "type": "file"
@@ -53,7 +53,7 @@
 "items": [
 {
 "name": "Manual suite name",
-"status": "status 2",
+"status": "passed",
 "items": [
 {
 "name": "Manual test name",

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-03/job-manual-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-03/job-manual-03.golden.json
@@ -1,13 +1,13 @@
 {
 "name": "job-manual-03",
-"status": "status-from-manual-results",
+"status": "passed",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "manual-results.yaml",
-"status": "status-from-manual-results",
+"status": "passed",
 "meta": {
 "file": "results/global/manual-results.yaml",
 "type": "file"
@@ -15,7 +15,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "passed",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -23,7 +23,7 @@
 "items": [
 {
 "name": "Manual suite name",
-"status": "status 2",
+"status": "passed",
 "items": [
 {
 "name": "Manual test name",

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
@@ -1,13 +1,13 @@
 {
 "name": "job-manual-04",
-"status": "status-from-default-sonobuoy-results",
+"status": "passed",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "sonobuoy_results.yaml",
-"status": "status-from-default-sonobuoy-results",
+"status": "passed",
 "meta": {
 "file": "results/global/sonobuoy_results.yaml",
 "type": "file"
@@ -15,7 +15,7 @@
 "items": [
 {
 "name": "a test file",
-"status": "status 1",
+"status": "passed",
 "meta": {
 "file": "results/global/junit_01.xml",
 "type": "file"
@@ -23,7 +23,7 @@
 "items": [
 {
 "name": "Manual suite name",
-"status": "status 2",
+"status": "passed",
 "items": [
 {
 "name": "Manual test name",

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-arbitrary-details/job-manual-arbitrary-details.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-arbitrary-details/job-manual-arbitrary-details.golden.json
@@ -1,13 +1,13 @@
 {
 "name": "job-manual-arbitrary-details",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "manual-results-arbitrary-details.yaml",
-"status": "status-from-manual-results",
+"status": "status 1: 1",
 "meta": {
 "file": "results/global/manual-results-arbitrary-details.yaml",
 "type": "file"

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -567,7 +567,7 @@ func TestManualResultsJob(t *testing.T) {
 	resultsYaml := mustRunSonobuoyCommandWithContext(ctx, t, ns, resultsArgs)
 	var resultItem results.Item
 	yaml.Unmarshal(resultsYaml.Bytes(), &resultItem)
-	expectedStatus := "manual-results-1: 1, manual-results-2: 1"
+	expectedStatus := "custom-status: 1, failed: 1, passed: 2"
 	if resultItem.Status != expectedStatus {
 		t.Errorf("Expected plugin to have status: %v, got %v", expectedStatus, resultItem.Status)
 	}
@@ -597,7 +597,7 @@ func TestManualResultsDaemonSet(t *testing.T) {
 	// The number of nodes can be determined by the length of the items array in the resultItem as there is an
 	// entry for every node where the plugin ran.
 	numNodes := len(resultItem.Items)
-	expectedStatus := fmt.Sprintf("manual-results-1: %v, manual-results-2: %v", numNodes, numNodes)
+	expectedStatus := fmt.Sprintf("custom-status: %v, failed: %v, passed: %v", numNodes, numNodes, numNodes*2)
 	if resultItem.Status != expectedStatus {
 		t.Errorf("Expected plugin to have status: %v, got %v", expectedStatus, resultItem.Status)
 	}


### PR DESCRIPTION
- manual plugins now use the same code paths
 - daemonsets use the same code paths
 - if only known status values (pass/fail/etc) we use the same rules to
aggregate the values
 - in all other cases we roll them up using values like "custom: 1, foo: 2"

This will be easier to debug, document, and utilize and it fixes 2 separate issues.

Fixes https://github.com/vmware-tanzu/sonobuoy/issues/1750
Fixes https://github.com/vmware-tanzu/sonobuoy/issues/1754

Signed-off-by: John Schnake <jschnake@vmware.com>