### PR TITLE
Move to registry.k8s.io

### DIFF
--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -418,9 +418,9 @@ func translateRegistry(imageURL string, customRegistry string, customRegistryLis
 		registryAndUser = customRegistryList.E2eRegistry
 	case "gcr.io/kubernetes-e2e-test-images/volume":
 		registryAndUser = customRegistryList.E2eVolumeRegistry
-	case "k8s.gcr.io":
+	case "k8s.gcr.io", "registry.k8s.io":
 		registryAndUser = customRegistryList.GcRegistry
-	case "k8s.gcr.io/sig-storage":
+	case "k8s.gcr.io/sig-storage", "registry.k8s.io/sig-storage":
 		registryAndUser = customRegistryList.SigStorageRegistry
 	case "gcr.io/k8s-authenticated-test":
 		registryAndUser = customRegistryList.PrivateRegistry

--- a/cmd/sonobuoy/app/images_test.go
+++ b/cmd/sonobuoy/app/images_test.go
@@ -56,11 +56,11 @@ func TestConvertImagesToPairs(t *testing.T) {
 	defer os.Remove(configFileName)
 
 	images := []string{
-		"k8s.gcr.io/etcd:3.4.13-0",
+		"registry.k8s.io/etcd:3.4.13-0",
 	}
 	expectedTagPairs := []image.TagPair{
 		{
-			Src: "k8s.gcr.io/etcd:3.4.13-0",
+			Src: "registry.k8s.io/etcd:3.4.13-0",
 			Dst: "test-fake-registry.corp/fake-user/etcd:3.4.13-0",
 		},
 	}

--- a/pkg/client/testdata/aggregatorpermissions-noncluster-admin.golden
+++ b/pkg/client/testdata/aggregatorpermissions-noncluster-admin.golden
@@ -60,7 +60,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -65,7 +65,7 @@ data:
         value: "1234"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -68,7 +68,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -63,7 +63,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -65,7 +65,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v99+static.testing
+      image: registry.k8s.io/conformance:v99+static.testing
       name: e2e
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ const (
 
 	// UpstreamKubeConformanceImageURL is the URL of the docker image to run for
 	// the kube conformance tests which is maintained by upstream Kubernetes.
-	UpstreamKubeConformanceImageURL = "k8s.gcr.io/conformance"
+	UpstreamKubeConformanceImageURL = "registry.k8s.io/conformance"
 	// DefaultAggregationServerBindPort is the default port for the aggregation server to bind to.
 	DefaultAggregationServerBindPort = 8080
 	// DefaultAggregationServerBindAddress is the default address for the aggregation server to bind to.

--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -19,29 +19,29 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	version "github.com/hashicorp/go-version"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/hashicorp/go-version"
+	"gopkg.in/yaml.v2"
 )
 
 const (
-	buildImageRegistry      = "k8s.gcr.io/build-image"
+	buildImageRegistry      = "registry.k8s.io/build-image"
 	dockerGluster           = "docker.io/gluster"
 	dockerLibraryRegistry   = "docker.io/library"
 	e2eRegistry             = "gcr.io/kubernetes-e2e-test-images"
 	e2eVolumeRegistry       = "gcr.io/kubernetes-e2e-test-images/volume"
 	etcdRegistry            = "quay.io/coreos"
 	gcAuthenticatedRegistry = "gcr.io/authenticated-image-pulling"
-	gcRegistry              = "k8s.gcr.io"
-	gcEtcdRegistry          = "k8s.gcr.io"
+	gcRegistry              = "registry.k8s.io"
+	gcEtcdRegistry          = "registry.k8s.io"
 	gcrReleaseRegistry      = "gcr.io/gke-release"
 	googleContainerRegistry = "gcr.io/google-containers"
 	invalidRegistry         = "invalid.com/invalid"
 	privateRegistry         = "gcr.io/k8s-authenticated-test"
-	promoterE2eRegistry     = "k8s.gcr.io/e2e-test-images"
+	promoterE2eRegistry     = "registry.k8s.io/e2e-test-images"
 	quayIncubator           = "quay.io/kubernetes_incubator"
 	quayK8sCSI              = "quay.io/k8scsi"
 	sampleRegistry          = "gcr.io/google-samples"
-	sigStorageRegistry      = "k8s.gcr.io/sig-storage"
+	sigStorageRegistry      = "registry.k8s.io/sig-storage"
 )
 
 // RegistryList holds public and private image registries

--- a/test/integration/testdata/gen-aggregator-permissions-clusterRead.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-clusterRead.golden
@@ -135,7 +135,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
+++ b/test/integration/testdata/gen-aggregator-permissions-namespaced.golden
@@ -96,7 +96,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: Never
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -115,7 +115,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -106,7 +106,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v9.8.7
+      image: registry.k8s.io/conformance:v9.8.7
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -103,7 +103,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-kube-test-repo.golden
+++ b/test/integration/testdata/gen-kube-test-repo.golden
@@ -107,7 +107,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-mode-and-focus.golden
+++ b/test/integration/testdata/gen-mode-and-focus.golden
@@ -104,7 +104,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-mode-and-rerun.golden
+++ b/test/integration/testdata/gen-mode-and-rerun.golden
@@ -104,7 +104,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-plugin-e2e-configmap.golden
+++ b/test/integration/testdata/gen-plugin-e2e-configmap.golden
@@ -42,7 +42,7 @@ spec:
     value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
-  image: k8s.gcr.io/conformance:v123.456.789
+  image: registry.k8s.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
   volumeMounts:

--- a/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
+++ b/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
@@ -43,7 +43,7 @@ spec:
     value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
-  image: k8s.gcr.io/conformance:v123.456.789
+  image: registry.k8s.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
   volumeMounts:

--- a/test/integration/testdata/gen-plugin-e2e.golden
+++ b/test/integration/testdata/gen-plugin-e2e.golden
@@ -42,7 +42,7 @@ spec:
     value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
-  image: k8s.gcr.io/conformance:v123.456.789
+  image: registry.k8s.io/conformance:v123.456.789
   imagePullPolicy: IfNotPresent
   name: e2e
   volumeMounts:

--- a/test/integration/testdata/gen-plugin-env-sonobuoy.golden
+++ b/test/integration/testdata/gen-plugin-env-sonobuoy.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -108,7 +108,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-security-context-none.golden
+++ b/test/integration/testdata/gen-security-context-none.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v123.456.789
+      image: registry.k8s.io/conformance:v123.456.789
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:v123.456.789
+      image: registry.k8s.io/conformance:v123.456.789
       imagePullPolicy: IfNotPresent
       name: e2e
       volumeMounts:

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -105,7 +105,7 @@ data:
         value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
-      image: k8s.gcr.io/conformance:ignore
+      image: registry.k8s.io/conformance:ignore
       imagePullPolicy: Always
       name: e2e
       volumeMounts:


### PR DESCRIPTION
The community is trying to reduce traffic to k8s.gcr.io
and is asking that people move to registry.k8s.io whenever
possible. Currently there is a proxy that will redirect you
so it won't break if we dont updata right away, but since
the change is so close, it is advised that we move now.

Fixes #1734

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Kubernetes images will now be pulled from registry.k8s.io instead of k8s.gcr.io, to be in alignment with current community initiatives.
```
