### PR TITLE
Allow worker to upload directory instead of file

### DIFF
--- a/test/integration/testImage/src/main.go
+++ b/test/integration/testImage/src/main.go
@@ -49,6 +49,10 @@ func main() {
 		"no-done", false,
 		"Use this if you want the plugin to exit without writing the done file to the worker.",
 	)
+	rootCmd.PersistentFlags().String(
+		"done", "",
+		"Set this if you want to explicitly write something into the done file; by using the empty value you let the command choose the appropriate value.",
+	)
 	rootCmd.AddCommand(cmdSingleFile)
 	rootCmd.AddCommand(cmdTarFile)
 	rootCmd.Execute()

--- a/test/integration/testImage/src/singleFileResults.go
+++ b/test/integration/testImage/src/singleFileResults.go
@@ -29,7 +29,7 @@ import (
 var cmdSingleFile = &cobra.Command{
 	Use:   "single-file",
 	Short: "Returns a single file as results.",
-	Long:  "Writes all the given files to the results directory but only writes the done file (if applicable) for the last one.",
+	Long:  "Writes all the given files to the results directory but only writes the done file (if applicable) for the first one.",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  reportSingleFile,
 }
@@ -51,6 +51,11 @@ func reportSingleFile(cmd *cobra.Command, args []string) error {
 		fmt.Println("no-done is set, exiting without writing done file")
 		return nil
 	}
+
+	if doneContents := cmd.Flags().Lookup("done").Value.String(); len(doneContents) > 0 {
+		resultsFile = doneContents
+	}
+
 	err := ioutil.WriteFile(doneFile, []byte(resultsFile), os.FileMode(0666))
 	return errors.Wrap(err, "failed to write to done file")
 }

--- a/test/integration/testImage/yaml/generate.sh
+++ b/test/integration/testImage/yaml/generate.sh
@@ -50,3 +50,13 @@ sonobuoy gen plugin \
 --arg="/tmp/sonobuoy/config/junit-via-configmap.xml" \
 --configmap="../resources/junit-via-configmap.xml" \
 --format="junit" > job-junit-singlefile-configmap.yaml
+
+sonobuoy gen plugin \
+--name=job-manual-directory \
+--image=sonobuoy/testimage:v0.1 \
+--cmd="/testImage" \
+--arg="single-file" \
+--arg="--done=/tmp/sonobuoy/results" \
+--arg="/resources/manual-results-1.yaml" \
+--arg="/resources/manual-results-2.yaml" \
+--format="manual" > job-manual-directory.yaml

--- a/test/integration/testImage/yaml/job-manual-directory.yaml
+++ b/test/integration/testImage/yaml/job-manual-directory.yaml
@@ -1,0 +1,15 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: job-manual-directory
+  result-format: manual
+spec:
+  args:
+  - single-file
+  - --done=/tmp/sonobuoy/results
+  - /resources/manual-results-1.yaml
+  - /resources/manual-results-2.yaml
+  command:
+  - /testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+


### PR DESCRIPTION
Current flow requires the plugin to tar up the results then
point to them. It would simplify things if we allowed pointing
to a directory and we do the tar process ourselves.

Fixes #1776

Signed-off-by: John Schnake <jschnake@vmware.com>