### PR TITLE
Manual all yaml

### DIFF
--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -194,7 +194,7 @@ func PostProcessPlugin(p plugin.Interface, dir string) (Item, []error) {
 	case ResultFormatManual:
 		logrus.WithField("plugin", p.GetName()).Trace("Using manual post-processor")
 		// Only process the specified plugin result files or a Sonobuoy results file.
-		i, errs = processPluginWithProcessor(p, dir, manualProcessFile, fileOrDefault(p.GetResultFiles(), PostProcessedResultsFile))
+		i, errs = processPluginWithProcessor(p, dir, manualProcessFile, FileOrExtension(p.GetResultFiles(), ".yaml", ".yml"))
 	default:
 		logrus.WithField("plugin", p.GetName()).Trace("Defaulting to raw post-processor")
 		// Default to raw format so that consumers can still expect the aggregate file to exist and
@@ -367,24 +367,6 @@ func sliceContains(set []string, val string) bool {
 		}
 	}
 	return false
-}
-
-// fileOrDefault returns a function which will return true for a filename that matches
-// the name of any file in the given list of files.
-// If no files are provided to search against, then the returned function will return
-// true for a filename that matches the given default filename.
-func fileOrDefault(files []string, defaultFile string) fileSelector {
-	return func(fPath string, info os.FileInfo) bool {
-		if info == nil || info.IsDir() {
-			return false
-		}
-
-		filename := filepath.Base(fPath)
-		if len(files) > 0 {
-			return sliceContains(files, filename)
-		}
-		return filename == defaultFile
-	}
 }
 
 // FileOrExtension returns a function which will return true for files

--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -35,10 +34,10 @@ import (
 
 var update = flag.Bool("update", false, "update golden files")
 
-// TestPostProcessPlugin runs a series of checks against basic combinations
+// TestPostProcessPluginGolden runs a series of checks against basic combinations
 // of options: (job|daemonset)+(raw|junit)+(specify a specific file or not)
 // and confirms the resulting Item is accurate.
-func TestPostProcessPlugin(t *testing.T) {
+func TestPostProcessPluginGolden(t *testing.T) {
 	getPlugin := func(key, pluginDriver, format string, outputFiles []string) plugin.Interface {
 		switch pluginDriver {
 		case "job":
@@ -163,7 +162,7 @@ func TestPostProcessPlugin(t *testing.T) {
 			key:    "job-junit-falsepositive",
 			plugin: getPlugin("job-junit-falsepositive", "job", "junit", []string{}),
 		}, {
-			desc:   "Job Manual results with no files specified and no default sonobuoy_results, all ignored",
+			desc:   "Job Manual results with no files specified and no default sonobuoy_results, processes yaml",
 			key:    "job-manual-01",
 			plugin: getPlugin("job-manual-01", "job", "manual", []string{}),
 		}, {
@@ -175,11 +174,11 @@ func TestPostProcessPlugin(t *testing.T) {
 			key:    "job-manual-03",
 			plugin: getPlugin("job-manual-03", "job", "manual", []string{"manual-results.yaml"}),
 		}, {
-			desc:   "Job Manual results with no file specified and default sonobuoy_results, default file processed",
+			desc:   "Job Manual results with no file specified and default sonobuoy_results, all yaml processed",
 			key:    "job-manual-04",
 			plugin: getPlugin("job-manual-04", "job", "manual", []string{}),
 		}, {
-			desc:   "DS Manual results with no file specified and no default sonobuoy_results, all ignored",
+			desc:   "DS Manual results with no file specified and no default sonobuoy_results, all yaml processed",
 			key:    "ds-manual-01",
 			plugin: getPlugin("ds-manual-01", "daemonset", "manual", []string{}),
 		}, {
@@ -191,7 +190,7 @@ func TestPostProcessPlugin(t *testing.T) {
 			key:    "ds-manual-03",
 			plugin: getPlugin("ds-manual-03", "daemonset", "manual", []string{"manual-results.yaml"}),
 		}, {
-			desc:   "DS Manual results with no file specified and default sonobuoy_results, default file processed",
+			desc:   "DS Manual results with no file specified and default sonobuoy_results, all yaml processed",
 			key:    "ds-manual-04",
 			plugin: getPlugin("ds-manual-04", "daemonset", "manual", []string{}),
 		}, {
@@ -599,64 +598,6 @@ func TestAggregateStatus(t *testing.T) {
 
 			if diff := pretty.Compare(tc.expectedItems, tc.input); diff != "" {
 				t.Errorf("\n\n%s\n", diff)
-			}
-		})
-	}
-}
-
-func TestFileOrDefault(t *testing.T) {
-	filesOnDisk := []string{
-		"testdata/mockResults/fileOrDefault/not-a-result-file.yaml",
-		"testdata/mockResults/fileOrDefault/result-file-1.yaml",
-		"testdata/mockResults/fileOrDefault/result-file-2.yaml",
-		"testdata/mockResults/fileOrDefault/sonobuoy_results.yaml",
-	}
-
-	testCases := []struct {
-		desc              string
-		pluginResultFiles []string
-		defaultFile       string
-		filesOnDisk       []string
-		expectedResults   []bool
-	}{
-		{
-			desc:            "Directory file on disk is not selected",
-			filesOnDisk:     []string{"testdata/mockResults/fileOrDefault"},
-			expectedResults: []bool{false},
-		},
-		{
-			desc:            "No plugin files and no default file result in no files being selected",
-			filesOnDisk:     filesOnDisk,
-			expectedResults: []bool{false, false, false, false},
-		},
-		{
-			desc:            "No plugin files and default file result in default file being selected",
-			filesOnDisk:     filesOnDisk,
-			defaultFile:     "sonobuoy_results.yaml",
-			expectedResults: []bool{false, false, false, true},
-		},
-		{
-			desc:              "Plugin files and default file result in only plugin files being selected",
-			filesOnDisk:       filesOnDisk,
-			pluginResultFiles: []string{"result-file-1.yaml", "result-file-2.yaml"},
-			defaultFile:       "sonobuoy_results.yaml",
-			expectedResults:   []bool{false, true, true, false},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			selector := fileOrDefault(tc.pluginResultFiles, tc.defaultFile)
-			// Simulate walk of results directory
-			for i, f := range tc.filesOnDisk {
-				fileInfo, err := os.Stat(f)
-				if err != nil {
-					t.Error(err)
-					continue
-				}
-				result := selector(f, fileInfo)
-				if result != tc.expectedResults[i] {
-					t.Errorf("expected selector for %v to return %v, got %v", f, tc.expectedResults[i], result)
-				}
 			}
 		})
 	}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/ds-manual-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-01/ds-manual-01.golden.json
@@ -1,23 +1,75 @@
 {
 "name": "ds-manual-01",
-"status": "unknown",
+"status": "status 2: 2",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "unknown",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "status 2: 1",
+"meta": {
+"file": "results/node1/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 2: 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
 }
+]
+}
+]
+}
+]
 },
 {
 "name": "node2",
-"status": "unknown",
+"status": "status 2: 1",
 "meta": {
 "type": "node"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "status 2: 1",
+"meta": {
+"file": "results/node2/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 2: 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
 }
+]
+}
+]
+}
+]
 }
 ]
 }

--- a/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-manual-04/ds-manual-04.golden.json
@@ -1,17 +1,41 @@
 {
 "name": "ds-manual-04",
-"status": "status 2: 2",
+"status": "status 2: 4",
 "meta": {
 "type": "summary"
 },
 "items": [
 {
 "name": "node1",
-"status": "status 2: 1",
+"status": "status 2: 2",
 "meta": {
 "type": "node"
 },
 "items": [
+{
+"name": "manual-results.yaml",
+"status": "status 2: 1",
+"meta": {
+"file": "results/node1/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 2: 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+},
 {
 "name": "sonobuoy_results.yaml",
 "status": "status 2: 1",
@@ -40,11 +64,35 @@
 },
 {
 "name": "node2",
-"status": "status 2: 1",
+"status": "status 2: 2",
 "meta": {
 "type": "node"
 },
 "items": [
+{
+"name": "manual-results.yaml",
+"status": "status 2: 1",
+"meta": {
+"file": "results/node2/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "status 2: 1",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "status 2"
+}
+]
+}
+]
+},
 {
 "name": "sonobuoy_results.yaml",
 "status": "status 2: 1",

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-01/job-manual-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-01/job-manual-01.golden.json
@@ -1,7 +1,39 @@
 {
 "name": "job-manual-01",
-"status": "unknown",
+"status": "passed",
 "meta": {
 "type": "summary"
+},
+"items": [
+{
+"name": "manual-results.yaml",
+"status": "passed",
+"meta": {
+"file": "results/global/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "passed",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "passed",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
 }
+]
+}
+]
+}
+]
+}
+]
 }

--- a/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-manual-04/job-manual-04.golden.json
@@ -6,6 +6,36 @@
 },
 "items": [
 {
+"name": "manual-results.yaml",
+"status": "passed",
+"meta": {
+"file": "results/global/manual-results.yaml",
+"type": "file"
+},
+"items": [
+{
+"name": "a test file",
+"status": "passed",
+"meta": {
+"file": "results/global/junit_01.xml",
+"type": "file"
+},
+"items": [
+{
+"name": "Manual suite name",
+"status": "passed",
+"items": [
+{
+"name": "Manual test name",
+"status": "passed"
+}
+]
+}
+]
+}
+]
+},
+{
 "name": "sonobuoy_results.yaml",
 "status": "passed",
 "meta": {

--- a/test/integration/testImage/yaml/job-manual.yaml
+++ b/test/integration/testImage/yaml/job-manual.yaml
@@ -2,9 +2,6 @@ sonobuoy-config:
   driver: Job
   plugin-name: job-manual
   result-format: manual
-  result-files:
-    - manual-results-1.yaml
-    - manual-results-2.yaml
 spec:
   args:
   - tar-file


### PR DESCRIPTION
The processor doesnt just look for sonobuoy_results.yaml but all yaml
files. This makes it easier for plugin authors. Even with my experience
with the codebase I made this mistake and wasted 20m investigating it.

Fixes #1782