### PR TITLE
Allow users to skip specific preflight checks

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -301,11 +301,12 @@ func AddRBACModeFlags(mode *RBACMode, flags *pflag.FlagSet, defaultMode RBACMode
 }
 
 // AddSkipPreflightFlag adds a boolean flag to skip preflight checks.
-func AddSkipPreflightFlag(flag *bool, flags *pflag.FlagSet) {
-	flags.BoolVar(
-		flag, "skip-preflight", false,
-		"If true, skip all checks before starting the sonobuoy run.",
+func AddSkipPreflightFlag(flag *[]string, flags *pflag.FlagSet) {
+	flags.StringSliceVar(
+		flag, "skip-preflight", []string{},
+		"Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.",
 	)
+	flags.Lookup("skip-preflight").NoOptDefVal = "true"
 }
 
 // AddDeleteAllFlag adds a boolean flag for deleting everything (including E2E tests).

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -50,7 +50,7 @@ type genFlags struct {
 
 	// These values are mainly for `run` but we want `gen` to support all the same
 	// flags so you can just swap out gen/run.
-	skipPreflight bool
+	skipPreflight []string
 	wait          int
 	waitOutput    WaitOutputMode
 	genFile       string

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -18,10 +18,11 @@ package app
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"os"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/client"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
@@ -82,11 +83,12 @@ func submitSonobuoyRun(f *genFlags) func(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		if !f.skipPreflight {
+		if !contains(f.skipPreflight, "true") && !contains(f.skipPreflight, "*") {
 			pcfg := &client.PreflightConfig{
-				Namespace:    f.sonobuoyConfig.Namespace,
-				DNSNamespace: f.dnsNamespace,
-				DNSPodLabels: f.dnsPodLabels,
+				Namespace:           f.sonobuoyConfig.Namespace,
+				DNSNamespace:        f.dnsNamespace,
+				DNSPodLabels:        f.dnsPodLabels,
+				PreflightChecksSkip: f.skipPreflight,
 			}
 			if errs := sbc.PreflightChecks(pcfg); len(errs) > 0 {
 				errlog.LogError(errors.New("Preflight checks failed"))

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -230,9 +230,10 @@ func (sc *StatusConfig) Validate() error {
 
 // PreflightConfig are the options passed to PreflightChecks.
 type PreflightConfig struct {
-	Namespace    string
-	DNSNamespace string
-	DNSPodLabels []string
+	Namespace           string
+	DNSNamespace        string
+	DNSPodLabels        []string
+	PreflightChecksSkip []string
 }
 
 // Validate checks the config to determine if it is valid.

--- a/test/integration/testdata/gen-mode-and-focus.golden
+++ b/test/integration/testdata/gen-mode-and-focus.golden
@@ -37,7 +37,7 @@ Flags:
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --service-account-name string              Name of the service account to be used by sonobuoy. (default "sonobuoy-serviceaccount")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
-      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
+      --skip-preflight strings[=true]            Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.

--- a/test/integration/testdata/gen-mode-and-rerun.golden
+++ b/test/integration/testdata/gen-mode-and-rerun.golden
@@ -37,7 +37,7 @@ Flags:
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --service-account-name string              Name of the service account to be used by sonobuoy. (default "sonobuoy-serviceaccount")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
-      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
+      --skip-preflight strings[=true]            Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.

--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -37,7 +37,7 @@ Flags:
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --service-account-name string              Name of the service account to be used by sonobuoy. (default "sonobuoy-serviceaccount")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
-      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
+      --skip-preflight strings[=true]            Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -37,7 +37,7 @@ Flags:
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --service-account-name string              Name of the service account to be used by sonobuoy. (default "sonobuoy-serviceaccount")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
-      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
+      --skip-preflight strings[=true]            Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -37,7 +37,7 @@ Flags:
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --service-account-name string              Name of the service account to be used by sonobuoy. (default "sonobuoy-serviceaccount")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
-      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
+      --skip-preflight strings[=true]            Skips the specified preflight checks. Valid values are [dnscheck, versioncheck, existingnamespace] or true to skip all of the checks.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.


### PR DESCRIPTION
Allow users to skip specific preflight checks using a new flag **skip-preflight-check**

The new flag was added since changing the flag type to string slice from bool requires an input value which would break any automation calling Sonobuoy from the CLI with --skip-preflight and no value.