### PR TITLE
WIP Reduce e2e data size

### DIFF
--- a/scripts/gather_e2e_data.sh
+++ b/scripts/gather_e2e_data.sh
@@ -3,10 +3,12 @@ set -ex
 
 sonobuoy run -p ./gathere2e/gathere2e.yaml --wait
 sonobuoy retrieve -x tmpoutput
-cp -f tmpoutput/plugins/gathere2e/results/global/* ../cmd/sonobuoy/app/e2e/testLists
+cp -f tmpoutput/plugins/gathere2e/results/global/* ../cmd/sonobuoy/app/e2e/v2/testLists
+sonobuoy delete
+rm -rf tmpoutput
+
+# ./minimize_e2e_data.sh
 (
   cd ../cmd/sonobuoy/app/e2e/testLists/
   find . -regex '.*[0-9]$' -exec gzip -f {} \;
 )
-sonobuoy delete
-rm -rf tmpoutput

--- a/scripts/minimize_e2e_data.sh
+++ b/scripts/minimize_e2e_data.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )"
+cd ${SCRIPT_DIR}/../cmd/sonobuoy/app/e2e/v2/testLists
+
+prevVer=""
+for minor in $(seq 15 99)
+do
+  IFS=$'\n' read -r -d '' -a versions < <(ls | grep "1.${minor}\.[0-9]*$" | sort -t "." -k1,1n -k2,2n -k3,3n)
+
+  if [[ ${#versions[@]} -eq 0 ]]
+  then
+    continue
+  fi
+  echo "Minor version ${minor} has "${#versions[@]}" point releases to consider..."
+
+  for ver in "${versions[@]}"
+  do
+    if [ "${prevVer}" == "" ]
+    then
+      echo "Using ${ver} as base version"
+      #minVer="${ver}.txt"
+      mv "${ver}" "${ver}.txt"
+      #first="false"
+      prevVer="${ver}"
+      continue
+    fi
+    echo "Processing version ${ver}"
+
+    # Header to reference the minVer list of tests.
+    #echo "#${minVer}" > "${ver}.txt"
+    echo "#${prevVer}" > "${ver}.txt"
+
+    IFS=$'\n' read -r -d '' -a addTests < <(comm -13 "$prevVer" "$ver")
+    echo "  Adding ${#addTests[@]} tests to base version"
+    for t in "${addTests[@]}"
+    do
+      echo "+${t}" >> "${ver}.txt"
+    done
+
+    IFS=$'\n' read -r -d '' -a removeTests < <(comm -23 "$prevVer" "$ver")
+    echo "  Removing ${#removeTests[@]} tests from base version"
+    for t in "${removeTests[@]}"
+    do
+      echo "-${t}" >> "${ver}.txt"
+    done
+
+    prevVer="${ver}"
+  done
+
+  echo done with minor version ${minor}
+  echo
+
+done


### PR DESCRIPTION
Related to #1650 

This is a draft PR, just a WIP I wanted to persist of how to 'compress' the e2e data.

It is in a messy state because I was going back/forth tweaking some things but the general approach someone can take/run with.

It will iterate through the versions of e2e data, choose the first one as a base and then update the others so that it references the base set of tests and also adds/removes other tests.

The goal of this approach would be that you can leave the data in *.txt form so its easy to see/edit rather than *.gz data which is harder to validate in a PR for instance.