### PR TITLE
Update goversion for goreleaser

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
If the older go version is used, a go mod difference will be detected
and goreleaser will fail.

Fixes #1826

Signed-off-by: John Schnake <jschnake@vmware.com>