### PR TITLE
Fix syntax error in k8s release workflow

### DIFF
--- a/.github/workflows/k8sRelease.yaml
+++ b/.github/workflows/k8sRelease.yaml
@@ -14,7 +14,7 @@ jobs:
       run: |
         echo wasRelease=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r '.published_at|fromdateiso8601 > now-86400') >> $GITHUB_OUTPUT
     - name: Create issue
-      if: ${{ steps.release-check.outputs.wasRelease }} == 'true'
+      if: ${{ steps.release-check.outputs.wasRelease == 'true' }}
       uses: imjohnbo/issue-bot@v3
       with:
         labels: "kind/required"


### PR DESCRIPTION
Signed-off-by: Dave Riddle <driddle@vmware.com>


**What this PR does / why we need it**:

Fixes our k8s issue check bot. With the recent syntax change to remove deprecation warnings, we ended up with an evaluation that would always return true.