### PR TITLE
Add brew installation to README, fix broken plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
 
 ## Installation
 
+The following methods exist for installing Sonobuoy:
+
+### Install binary
+
 1. Download the [latest release][releases] for your client platform.
 2. Extract the tarball:
 
@@ -45,6 +49,14 @@ more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
    ```
 
    Move the extracted `sonobuoy` executable to somewhere on your `PATH`.
+
+### Install with Hombrew (MacOS)
+
+1. Run the command:
+  
+   ```
+   brew install sonobuoy
+   ```
 
 ## Getting Started
 

--- a/site/content/docs/main/_index.md
+++ b/site/content/docs/main/_index.md
@@ -43,6 +43,10 @@ more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
 
 ## Installation
 
+The following methods exist for installing Sonobuoy:
+
+### Install binary
+
 1. Download the [latest release][releases] for your client platform.
 2. Extract the tarball:
 
@@ -51,6 +55,14 @@ more about the new release cycles in [our blog][decoupling-sonobuoy-k8s].
    ```
 
    Move the extracted `sonobuoy` executable to somewhere on your `PATH`.
+
+### Install with Hombrew (MacOS)
+
+1. Run the command:
+  
+   ```
+   brew install sonobuoy
+   ```
 
 ## Getting Started
 

--- a/site/content/plugins/list/02-end-to-end-testing.md
+++ b/site/content/plugins/list/02-end-to-end-testing.md
@@ -5,4 +5,4 @@ link: https://sonobuoy.io/docs/main/e2eplugin/
 
 The Kubernetes end-to-end testing plugin (the e2e plugin) is used to run tests which are maintained by the upstream Kubernetes community in the [kubernetes/kubernetes][1] repo.
 
-[1]: https://github.com/kubernetes/kubernetes/tree/main/cluster/images/conformance
+[1]: https://github.com/kubernetes/kubernetes/tree/master/test/conformance/image


### PR DESCRIPTION
Signed-off-by: Jon Ji <jchenjun@vmware.com>

**What this PR does / why we need it**:
- Add missing instructions on how to install on MacOS with homebrew
- Fix broken link to kubernetes conformance image on plugin page