### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -8,10 +8,10 @@ jobs:
       - name: golangci-lint run
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.52.2
           skip-pkg-cache: true
           skip-build-cache: true
-          args: --timeout=2m0s -v
+          args: --timeout=5m0s -v
   bash-lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -35,7 +35,7 @@ PPC64LE_IMAGE=gcr.io/distroless/static:nonroot-ppc64le
 S390X_IMAGE=gcr.io/distroless/static:nonroot-s390x
 WIN_AMD64_BASEIMAGE=mcr.microsoft.com/windows/nanoserver
 TEST_IMAGE=testimage:v0.1
-LINT_IMAGE=golangci/golangci-lint:v1.50
+LINT_IMAGE=golangci/golangci-lint:v1.52.2
 KIND_CLUSTER=kind
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )"
@@ -85,7 +85,7 @@ local_integration(){
 
 lint() {
   docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $LINT_IMAGE /bin/sh -c \
-    "golangci-lint run --out-format=github-actions --timeout=2m0s -v"
+    "golangci-lint run --out-format=github-actions --timeout=5m0s -v"
 }
 
 vet() {


### PR DESCRIPTION
**What this PR does / why we need it**:
 Updates failing lint. Upgrades golangci-lint version and increases timeout to account for increase in tests and test runners.