### PR TITLE
Add support for injecting tolerations to sonobuoy pod

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: golangci-lint run
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.2
           skip-pkg-cache: true
           skip-build-cache: true
           args: --timeout=5m0s -v
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: go mod tidy
         run: |
           ./scripts/ci/check_go_modules.sh

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,16 +147,17 @@ type Config struct {
 	///////////////////////////////////////////////
 	// Sonobuoy configuration
 	///////////////////////////////////////////////
-	WorkerImage              string            `json:"WorkerImage" mapstructure:"WorkerImage"`
-	ImagePullPolicy          string            `json:"ImagePullPolicy" mapstructure:"ImagePullPolicy"`
-	ForceImagePullPolicy     bool              `json:"ForceImagePullPolicy,omitempty" mapstructure:"ForceImagePullPolicy"`
-	ImagePullSecrets         string            `json:"ImagePullSecrets" mapstructure:"ImagePullSecrets"`
-	CustomAnnotations        map[string]string `json:"CustomAnnotations,omitempty" mapstructure:"CustomAnnotations"`
-	AggregatorPermissions    string            `json:"AggregatorPermissions" mapstructure:"AggregatorPermissions"`
-	ServiceAccountName       string            `json:"ServiceAccountName" mapstructure:"ServiceAccountName"`
-	ExistingServiceAccount   bool              `json:"ExistingServiceAccount,omitempty" mapstructure:"ExistingServiceAccount,omitempty"`
-	E2EDockerConfigFile      string            `json:"E2EDockerConfigFile,omitempty" mapstructure:"E2EDockerConfigFile,omitempty"`
-	NamespacePSAEnforceLevel string            `json:"NamespacePSAEnforceLevel,omitempty" mapstructure:"NamespacePSAEnforceLevel,omitempty"`
+	WorkerImage              string              `json:"WorkerImage" mapstructure:"WorkerImage"`
+	ImagePullPolicy          string              `json:"ImagePullPolicy" mapstructure:"ImagePullPolicy"`
+	ForceImagePullPolicy     bool                `json:"ForceImagePullPolicy,omitempty" mapstructure:"ForceImagePullPolicy"`
+	ImagePullSecrets         string              `json:"ImagePullSecrets" mapstructure:"ImagePullSecrets"`
+	CustomAnnotations        map[string]string   `json:"CustomAnnotations,omitempty" mapstructure:"CustomAnnotations"`
+	AggregatorPermissions    string              `json:"AggregatorPermissions" mapstructure:"AggregatorPermissions"`
+	AggregatorTolerations    []map[string]string `json:"AggregatorTolerations,omitempty" mapstructure:"AggregatorTolerations"`
+	ServiceAccountName       string              `json:"ServiceAccountName" mapstructure:"ServiceAccountName"`
+	ExistingServiceAccount   bool                `json:"ExistingServiceAccount,omitempty" mapstructure:"ExistingServiceAccount,omitempty"`
+	E2EDockerConfigFile      string              `json:"E2EDockerConfigFile,omitempty" mapstructure:"E2EDockerConfigFile,omitempty"`
+	NamespacePSAEnforceLevel string              `json:"NamespacePSAEnforceLevel,omitempty" mapstructure:"NamespacePSAEnforceLevel,omitempty"`
 
 	// ProgressUpdatesPort is the port on which the Sonobuoy worker will listen for status updates from its plugin.
 	ProgressUpdatesPort string `json:"ProgressUpdatesPort,omitempty" mapstructure:"ProgressUpdatesPort"`

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -35,7 +35,7 @@ PPC64LE_IMAGE=gcr.io/distroless/static:nonroot-ppc64le
 S390X_IMAGE=gcr.io/distroless/static:nonroot-s390x
 WIN_AMD64_BASEIMAGE=mcr.microsoft.com/windows/nanoserver
 TEST_IMAGE=testimage:v0.1
-LINT_IMAGE=golangci/golangci-lint:v1.52.2
+LINT_IMAGE=golangci/golangci-lint:v1.54.2
 KIND_CLUSTER=kind
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )"

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -28,7 +28,7 @@ IMAGE_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF_LONG=$(git rev-parse --verify HEAD)
 
 BUILDMNT=/go/src/$GOTARGET
-BUILD_IMAGE=golang:1.21.11
+BUILD_IMAGE=golang:1.21.12
 AMD_IMAGE=gcr.io/distroless/static:nonroot
 ARM_IMAGE=gcr.io/distroless/static:nonroot-arm64
 PPC64LE_IMAGE=gcr.io/distroless/static:nonroot-ppc64le

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -13,7 +13,7 @@ LINUX_ARCH=(amd64 arm64 ppc64le s390x)
 
 # Currently only under a single arch, can iterate over these and still assume arch value.
 WIN_ARCH=amd64
-WINVERSIONS=("1809" "1903" "1909" "2004" "20H2")
+WINVERSIONS=("ltsc2022")
 
 # Not used for pushing images, just for local building on other GOOS. Defaults to
 # grabbing from the local go env but can be set manually to avoid that requirement.

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -28,7 +28,7 @@ IMAGE_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF_LONG=$(git rev-parse --verify HEAD)
 
 BUILDMNT=/go/src/$GOTARGET
-BUILD_IMAGE=golang:1.21.4
+BUILD_IMAGE=golang:1.21.11
 AMD_IMAGE=gcr.io/distroless/static:nonroot
 ARM_IMAGE=gcr.io/distroless/static:nonroot-arm64
 PPC64LE_IMAGE=gcr.io/distroless/static:nonroot-ppc64le

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.11 AS base
+FROM golang:1.21.12 AS base
 WORKDIR /src
 
 # Handle the go modules first to take advantage of Docker cache.

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.4 AS base
+FROM golang:1.21.11 AS base
 WORKDIR /src
 
 # Handle the go modules first to take advantage of Docker cache.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for injecting tolerations to sonobuoy pod

**Which issue(s) this PR fixes**
- Fixes #1973.

We can inject some tolerations to sonobuoy aggregator pod by adding trailing description into sonobuoy config json.

```json
{
  "AggregatorTolerations": [
    {
      "effect": "NoSchedule",
      "key": "key1",
      "operator": "Equal",
      "value": "value1"
    },
    {
      "effect": "NoSchedule",
      "key": "key2",
      "operator": "Equal",
      "value": "value2"
    }
  ]
}
```

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
