### PR TITLE
update golang

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -6,9 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint run
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54.2
+          version: v1.61.0
           skip-pkg-cache: true
           skip-build-cache: true
           args: --timeout=5m0s -v
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.23
       - name: go mod tidy
         run: |
           ./scripts/ci/check_go_modules.sh

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.23
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/sonobuoy
 
-go 1.21
+go 1.23
 
 require (
 	github.com/briandowns/spinner v1.19.0

--- a/scripts/build_funcs.sh
+++ b/scripts/build_funcs.sh
@@ -28,14 +28,14 @@ IMAGE_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF_LONG=$(git rev-parse --verify HEAD)
 
 BUILDMNT=/go/src/$GOTARGET
-BUILD_IMAGE=golang:1.21.12
+BUILD_IMAGE=golang:1.23.1
 AMD_IMAGE=gcr.io/distroless/static:nonroot
 ARM_IMAGE=gcr.io/distroless/static:nonroot-arm64
 PPC64LE_IMAGE=gcr.io/distroless/static:nonroot-ppc64le
 S390X_IMAGE=gcr.io/distroless/static:nonroot-s390x
 WIN_AMD64_BASEIMAGE=mcr.microsoft.com/windows/nanoserver
 TEST_IMAGE=testimage:v0.1
-LINT_IMAGE=golangci/golangci-lint:v1.54.2
+LINT_IMAGE=golangci/golangci-lint:v1.61.0
 KIND_CLUSTER=kind
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )"
@@ -84,7 +84,7 @@ local_integration(){
 }
 
 lint() {
-  docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $LINT_IMAGE /bin/sh -c \
+  docker run --rm -v "$(pwd)":$BUILDMNT -w $BUILDMNT $LINT_IMAGE /bin/sh -c \F
     "golangci-lint run --out-format=github-actions --timeout=5m0s -v"
 }
 

--- a/test/integration/testImage/Dockerfile
+++ b/test/integration/testImage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.12 AS base
+FROM golang:1.23.1 AS base
 WORKDIR /src
 
 # Handle the go modules first to take advantage of Docker cache.

--- a/test/integration/testImage/src/go.mod
+++ b/test/integration/testImage/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/sonobuoy/test/integration/testImage/src
 
-go 1.21
+go 1.23
 
 require (
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates golang version. Addresses CVE-2024-34156, CVE-2024-34155, CVE-2024-34158.

**Release note**:
```
updated golang to 1.23.1
```
