### PR TITLE
Update golangci errcheck config

### DIFF
--- a/.errcheck.list
+++ b/.errcheck.list
@@ -1,8 +1,0 @@
-github.com/imdario/mergo.Merge
-github.com/spf13/viper.BindEnv
-(github.com/spf13/pflag.Value).Set
-(*github.com/briandowns/spinner.Spinner).Color
-(*github.com/spf13/cobra.Command).MarkFlagRequired
-(*github.com/spf13/cobra.Command).Help
-(*github.com/spf13/pflag.FlagSet).MarkHidden
-(*github.com/spf13/pflag.FlagSet).Set

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,4 +2,13 @@ run:
   tests: false
 linters-settings:
   errcheck:
-    exclude: ./.errcheck.list
+    # Keyword `exclude` is removed: https://golangci-lint.run/usage/linters/#errcheck
+    exclude-functions:
+    - github.com/imdario/mergo.Merge
+    - github.com/spf13/viper.BindEnv
+    - (github.com/spf13/pflag.Value).Set
+    - (*github.com/briandowns/spinner.Spinner).Color
+    - (*github.com/spf13/cobra.Command).MarkFlagRequired
+    - (*github.com/spf13/cobra.Command).Help
+    - (*github.com/spf13/pflag.FlagSet).MarkHidden
+    - (*github.com/spf13/pflag.FlagSet).Set


### PR DESCRIPTION
**What this PR does / why we need it**:
Got error with golangci lint https://github.com/vmware-tanzu/sonobuoy/actions/runs/13397812497/job/37421083123
Since the exclude keyword was removed  https://golangci-lint.run/usage/linters/#errcheck
**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
none
```
