### PR TITLE
Add weekly linux vuln scan

### DIFF
--- a/.github/workflows/weekly-vulnerability-scan.yaml
+++ b/.github/workflows/weekly-vulnerability-scan.yaml
@@ -1,0 +1,41 @@
+name: Weekly Linux Vulnerability Scan
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Run at midnight every Sunday
+  workflow_dispatch:     # Allow manual triggering
+
+jobs:
+  linux-vulnerability-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+
+      - name: Show history for debug help
+        run: |
+          git log --oneline -n 5
+
+      - name: Build Docker image
+        id: build-image
+        run: |
+          source ./scripts/build.sh
+          
+          # Build the amd64 binary
+          build_binary_GOOS_GOARCH linux amd64
+          
+          # Build the container image for amd64
+          gen_dockerfile_for_os_arch linux amd64
+          build_container_dockerfile_arch build/linux/amd64/Dockerfile amd64
+          
+          # Export the image tag using the IMAGE_VERSION variable already set in build_funcs.sh
+          echo "image_version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: sonobuoy/sonobuoy:amd64-${{ steps.build-image.outputs.image_version }}
+          format: 'table'
+          exit-code: '1'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a new GitHub workflow for weekly vulnerability scanning of Sonobuoy image. This helps us proactively identify security vulnerabilities before they become critical issues.

**Which issue(s) this PR fixes** : Addresses review comment by @lubronzhan https://github.com/vmware-tanzu/sonobuoy/pull/2012#issuecomment-2734339504

**Special notes for your reviewer**: Since manual workflow is enabled, the workflow will show up once merged in main

test run: https://github.com/farazkhawaja/sonobuoy/actions/runs/14548728237 -- tested on a older branch with vuln issues. _job fails when there is a vuln detected_


